### PR TITLE
Add support for toggling mouse acceleration

### DIFF
--- a/debian/patches/pop_mouse_accel.patch
+++ b/debian/patches/pop_mouse_accel.patch
@@ -1,0 +1,129 @@
+Index: gnome-control-center/panels/mouse/gnome-mouse-properties.c
+===================================================================
+--- gnome-control-center.orig/panels/mouse/gnome-mouse-properties.c
++++ gnome-control-center/panels/mouse/gnome-mouse-properties.c
+@@ -51,6 +51,7 @@ struct _CcMouseProperties
+ 	GtkWidget *general_listbox;
+ 	GtkWidget *mouse_frame;
+ 	GtkWidget *mouse_listbox;
++	GtkWidget *mouse_acceleration_enable_switch;
+ 	GtkWidget *mouse_natural_scrolling_switch;
+ 	GtkWidget *mouse_speed_scale;
+ 	GtkWidget *primary_button_left;
+@@ -199,6 +200,31 @@ touchpad_enabled_set_mapping (const GVal
+         return g_variant_new_string (enabled ? "enabled" : "disabled");
+ }
+ 
++static gboolean
++mouse_acceleration_enabled_get_mapping (GValue    *value,
++                              GVariant  *variant,
++                              gpointer   user_data)
++{
++        gboolean enabled;
++
++        enabled = g_strcmp0 (g_variant_get_string (variant, NULL), "flat") != 0;
++        g_value_set_boolean (value, enabled);
++
++        return TRUE;
++}
++
++static GVariant *
++mouse_acceleration_enabled_set_mapping (const GValue    *value,
++                              const GVariantType        *type,
++                              gpointer                   user_data)
++{
++        gboolean enabled;
++
++        enabled = g_value_get_boolean (value);
++
++        return g_variant_new_string (enabled ? "adaptive" : "flat");
++}
++
+ static void
+ handle_secondary_button (CcMouseProperties *self,
+ 			 GtkWidget         *button,
+@@ -251,6 +277,13 @@ setup_dialog (CcMouseProperties *self)
+ 			 gtk_range_get_adjustment (GTK_RANGE (self->mouse_speed_scale)), "value",
+ 			 G_SETTINGS_BIND_DEFAULT);
+ 
++	g_settings_bind_with_mapping (self->mouse_settings, "accel-profile",
++			 self->mouse_acceleration_enable_switch, "active",
++			 G_SETTINGS_BIND_DEFAULT,
++			 mouse_acceleration_enabled_get_mapping, 
++			 mouse_acceleration_enabled_set_mapping, 
++			 NULL, NULL);
++
+ 	gtk_list_box_set_header_func (GTK_LIST_BOX (self->mouse_listbox), cc_list_box_update_header_func, NULL, NULL);
+ 
+ 	/* Touchpad section */
+@@ -387,6 +420,7 @@ cc_mouse_properties_class_init (CcMouseP
+ 	gtk_widget_class_bind_template_child (widget_class, CcMouseProperties, general_listbox);
+ 	gtk_widget_class_bind_template_child (widget_class, CcMouseProperties, mouse_frame);
+ 	gtk_widget_class_bind_template_child (widget_class, CcMouseProperties, mouse_listbox);
++	gtk_widget_class_bind_template_child (widget_class, CcMouseProperties, mouse_acceleration_enable_switch);
+ 	gtk_widget_class_bind_template_child (widget_class, CcMouseProperties, mouse_natural_scrolling_switch);
+ 	gtk_widget_class_bind_template_child (widget_class, CcMouseProperties, mouse_speed_scale);
+ 	gtk_widget_class_bind_template_child (widget_class, CcMouseProperties, primary_button_left);
+Index: gnome-control-center/panels/mouse/gnome-mouse-properties.ui
+===================================================================
+--- gnome-control-center.orig/panels/mouse/gnome-mouse-properties.ui
++++ gnome-control-center/panels/mouse/gnome-mouse-properties.ui
+@@ -256,6 +256,58 @@
+                           </object>
+                         </child>
+                         <child>
++                          <object class="GtkListBoxRow" id="mouse_acceleration_enable_row">
++                            <property name="visible">True</property>
++                            <property name="can_focus">True</property>
++                            <property name="activatable">false</property>
++                            <child>
++                              <object class="GtkGrid" id="mouse_acceleration_enable_grid">
++                              <property name="visible">True</property>
++                              <property name="can_focus">False</property>
++                              <property name="row_spacing">0</property>
++                              <property name="column_spacing">32</property>
++                              <property name="margin_start">20</property>
++                              <property name="margin_end">20</property>
++                              <property name="margin_top">12</property>
++                              <property name="margin_bottom">12</property>
++                              <property name="valign">center</property>
++                                <child>
++                                  <object class="GtkLabel" id="mouse_acceleration_enable_label">
++                                    <property name="visible">True</property>
++                                    <property name="can_focus">False</property>
++                                    <property name="hexpand">True</property>
++                                    <property name="xalign">0</property>
++                                    <property name="valign">end</property>
++                                    <property name="label" translatable="yes">Mouse Acceleration</property>
++                                    <property name="use_underline">True</property>
++                                    <property name="mnemonic_widget">mouse_acceleration_enable_switch</property>
++                                  </object>
++                                  <packing>
++                                    <property name="left_attach">0</property>
++                                    <property name="top_attach">0</property>
++                                    <property name="width">1</property>
++                                    <property name="height">1</property>
++                                  </packing>
++                                </child>
++                                <child>
++                                  <object class="GtkSwitch" id="mouse_acceleration_enable_switch">
++                                    <property name="visible">True</property>
++                                    <property name="can_focus">True</property>
++                                    <property name="halign">end</property>
++                                    <property name="valign">center</property>
++                                  </object>
++                                  <packing>
++                                    <property name="left_attach">1</property>
++                                    <property name="top_attach">0</property>
++                                    <property name="width">1</property>
++                                    <property name="height">2</property>
++                                  </packing>
++                                </child>
++                              </object>
++                            </child>
++                          </object>
++                        </child>
++                        <child>
+                           <object class="GtkListBoxRow" id="mouse_natural_scrolling_row">
+                             <property name="visible">True</property>
+                             <property name="can_focus">True</property>

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -33,3 +33,4 @@ git_nightlight_translations.patch
 pop_allow_sound_above_100.patch
 pop_shop.patch
 pop_appearance.patch
+pop_mouse_accel.patch


### PR DESCRIPTION
Useful to, and often required by, artists and designers, as well as gamers, to improve mouse precision.

Disabling acceleration sets the accel profile to "flat". Enabled is the default "adaptive" profile.

Patch diff from https://gitlab.gnome.org/mathewbouma/gnome-control-center/commit/76ec754c3b3f37f9675531d8908f5b061fcfac97.diff

Originating from https://gitlab.gnome.org/GNOME/gnome-control-center/merge_requests/296

![Screenshot from 2019-04-19 14-32-58](https://user-images.githubusercontent.com/4143535/56443033-0f2ec400-62b0-11e9-9da4-c02e6fb3a94a.png)
