### PR TITLE
Fix a stack overflow when turning displays off and on

### DIFF
--- a/debian/patches/display-stack-overflow.patch
+++ b/debian/patches/display-stack-overflow.patch
@@ -1,0 +1,14 @@
+Index: gnome-control-center/panels/display/cc-display-panel.c
+===================================================================
+--- gnome-control-center.orig/panels/display/cc-display-panel.c
++++ gnome-control-center/panels/display/cc-display-panel.c
+@@ -727,6 +727,9 @@ rebuild_ui (CcDisplayPanel *panel)
+   GList *outputs, *l;
+   CcDisplayConfigType type;
+ 
++  if (panel->rebuilding_counter > 0)
++    return;
++
+   panel->rebuilding_counter++;
+ 
+   g_list_store_remove_all (panel->primary_display_list);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -31,5 +31,6 @@ ubuntu_privacy_hide_buggy_controls.patch
 pop_allow_sound_above_100.patch
 pop_shop.patch
 pop_appearance.patch
-pop_hidpi.patch
 pop_mouse_accel.patch
+pop_hidpi.patch
+display-stack-overflow.patch


### PR DESCRIPTION
Fixes #39 

There's an upstream bug which causes the display panel to enter into a stack overflow when displays are turned off and on again, due to infinite recursion. I noticed that they have a `rebuilding_counter` variable for preventing recursion, so adding a check for `> 0` to the `build_ui` function prevents it from triggering recursion.

A fix will be submitted upstream once QA approves.