### PR TITLE
Uses @theme_fg_color for the drag handles instead of @borders

### DIFF
--- a/shell/style.css
+++ b/shell/style.css
@@ -1,3 +1,8 @@
 .drag-handle {
-    color: @borders;
-}
+    color: alpha(@theme_fg_color, 0.4);
+  }
+  
+  .drag-handle:backdrop {
+    color: alpha(@theme_unfocused_fg_color, 0.4);
+  }
+  


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/gnome-control-center/merge_requests/597

Fixes pop-os/gtk-theme#366