### PR TITLE
Add an option under "Tiling" set key binding to toggle auto-tiling

### DIFF
--- a/debian/patches/pop-shell.patch
+++ b/debian/patches/pop-shell.patch
@@ -90,9 +90,10 @@ Index: gnome-control-center/panels/keyboard/10-pop-shell-tile.xml.in
 ===================================================================
 --- /dev/null
 +++ gnome-control-center/panels/keyboard/10-pop-shell-tile.xml.in
-@@ -0,0 +1,5 @@
+@@ -0,0 +1,6 @@
 +<?xml version="1.0" encoding="UTF-8" ?>
 +<KeyListEntries group="system" schema="org.gnome.shell.extensions.pop-shell" name="Tiling">
 +    <KeyListEntry name="management-orientation" description="Change current window orientation"/>
 +    <KeyListEntry name="toggle-floating" description="Toggles a window between floating and tiling"/>
++    <KeyListEntry name="toggle-tiling" description="Toggles auto-tiling"/>
 +</KeyListEntries>


### PR DESCRIPTION
The should address  pop-os/shell#434.