### PR TITLE
Rename 'search' to 'activate-launcher', matching change in pop shell, fixing #93

### DIFF
--- a/debian/patches/pop-shell.patch
+++ b/debian/patches/pop-shell.patch
@@ -80,7 +80,7 @@ Index: gnome-control-center/panels/keyboard/10-pop-shell-navigate.xml.in
 @@ -0,0 +1,8 @@
 +<?xml version="1.0" encoding="UTF-8" ?>
 +<KeyListEntries group="system" schema="org.gnome.shell.extensions.pop-shell" name="Navigate applications and windows">
-+    <KeyListEntry name="search" description="Launch and switch applications"/>
++    <KeyListEntry name="activate-launcher" description="Launch and switch applications"/>
 +    <KeyListEntry name="focus-down" description="Switch focus to window down"/>
 +    <KeyListEntry name="focus-left" description="Switch focus to window left"/>
 +    <KeyListEntry name="focus-right" description="Switch focus to window right"/>


### PR DESCRIPTION
Depends on https://github.com/pop-os/shell/pull/436. Fixes #93.