### PR TITLE
patches: disable 0027-window-Stop-using-HdyLeaflet.patch

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -29,7 +29,7 @@ git-nongnome-segfault.patch
 # 0024-display-Allow-fractional-scaling-to-be-enabled.patch
 # 0025-applications-Hide-buttons-that-launch-gnome-software.patch
 # 0026-applications-Launch-snap-store-if-it-is-installed.patch
-0027-window-Stop-using-HdyLeaflet.patch
+# 0027-window-Stop-using-HdyLeaflet.patch
 0028-user-panel-Add-reference-to-selected-user-and-clear-.patch
 # 0029-applications-Use-new-snapd-glib-API-for-labelling-Sn.patch
 0029-user-panel-Don-t-wait-for-fprintd-on-initialization.patch


### PR DESCRIPTION
Fixes https://github.com/pop-os/gnome-control-center/issues/100.

See the description in [the patch](https://github.com/pop-os/gnome-control-center/blob/master_focal/debian/patches/0027-window-Stop-using-HdyLeaflet.patch) for the justification for patching this functionality out.