### PR TITLE
Fix typo in keyboard shortcut name: "uppwer" -> "upper"

### DIFF
--- a/debian/patches/pop-shell.patch
+++ b/debian/patches/pop-shell.patch
@@ -62,7 +62,7 @@ Index: gnome-control-center/panels/keyboard/10-pop-shell-move.xml.in
 +    <KeyListEntry name="pop-monitor-down" description="Move window to lower monitor"/>
 +    <KeyListEntry name="pop-monitor-left" description="move window to leftward monitor"/>
 +    <KeyListEntry name="pop-monitor-right" description="move window to rightward monitor"/>
-+    <KeyListEntry name="pop-monitor-up" description="Move window to uppwer monitor"/>
++    <KeyListEntry name="pop-monitor-up" description="Move window to upper monitor"/>
 +    <KeyListEntry name="tile-reject" description="Cancel changes"/>
 +    <KeyListEntry name="tile-resize-left" description="Resize window smaller"/>
 +    <KeyListEntry name="tile-resize-right" description="Resize window larger"/>


### PR DESCRIPTION
I noticed this small typo while setting up some keyboard shortcuts.

Thanks a lot for what you're doing, I really like the new option to stack tiled windows!