### PR TITLE
focal: Add patch to not enforce password strength requirements

### DIFF
--- a/debian/patches/0001-Do-not-enforce-password-strength-requirements.patch
+++ b/debian/patches/0001-Do-not-enforce-password-strength-requirements.patch
@@ -1,0 +1,60 @@
+From c329b4bea5aa79d54533a4148a8b5e7d8cdec3c6 Mon Sep 17 00:00:00 2001
+From: Ian Douglas Scott <idscott@system76.com>
+Date: Tue, 5 Jan 2021 08:24:44 -0800
+Subject: [PATCH] Do not enforce password strength requirements
+
+Gnome Initial Setup doesn't seem to be enforcing this, and since
+`libpam-pwquality` isn't installed by default, presumably tools like
+`passwd` aren't.
+
+Perhaps the way Gnome handles this could be done better.
+---
+ panels/user-accounts/cc-add-user-dialog.c | 4 ++--
+ panels/user-accounts/cc-password-dialog.c | 6 +++---
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/panels/user-accounts/cc-add-user-dialog.c b/panels/user-accounts/cc-add-user-dialog.c
+index 7a99b09dd..077301a38 100644
+--- a/panels/user-accounts/cc-add-user-dialog.c
++++ b/panels/user-accounts/cc-add-user-dialog.c
+@@ -269,10 +269,10 @@ update_password_strength (CcAddUserDialog *self)
+ 
+         verify = gtk_entry_get_text (self->local_verify_entry);
+         if (strlen (verify) == 0) {
+-                gtk_widget_set_sensitive (GTK_WIDGET (self->local_verify_entry), strength_level > 1);
++                gtk_widget_set_sensitive (GTK_WIDGET (self->local_verify_entry), TRUE);
+         }
+ 
+-        return strength_level;
++        return 2;
+ }
+ 
+ static gboolean
+diff --git a/panels/user-accounts/cc-password-dialog.c b/panels/user-accounts/cc-password-dialog.c
+index e803ed152..aac9271fd 100644
+--- a/panels/user-accounts/cc-password-dialog.c
++++ b/panels/user-accounts/cc-password-dialog.c
+@@ -104,10 +104,10 @@ update_password_strength (CcPasswordDialog *self)
+ 
+         verify = gtk_entry_get_text (self->verify_entry);
+         if (strlen (verify) == 0) {
+-                gtk_widget_set_sensitive (GTK_WIDGET (self->verify_entry), strength_level > 1);
++                gtk_widget_set_sensitive (GTK_WIDGET (self->verify_entry), TRUE);
+         }
+ 
+-        return strength_level;
++        return 2;
+ }
+ 
+ static void
+@@ -222,7 +222,7 @@ update_sensitivity (CcPasswordDialog *self)
+ 
+         if (self->password_mode == ACT_USER_PASSWORD_MODE_REGULAR) {
+                 strength = update_password_strength (self);
+-                can_change = strength > 1 && strcmp (password, verify) == 0 &&
++                can_change = strength > 1 && strlen(password) > 0 && strcmp (password, verify) == 0 &&
+                              (self->old_password_ok || !gtk_widget_get_visible (GTK_WIDGET (self->old_password_entry)));
+         }
+         else {
+-- 
+2.27.0

--- a/debian/patches/0002-users-Recreate-RunHandler-on-failure.patch
+++ b/debian/patches/0002-users-Recreate-RunHandler-on-failure.patch
@@ -1,0 +1,46 @@
+From b6adea6686b80ac8b596d5e37d2040a8ac80c651 Mon Sep 17 00:00:00 2001
+From: Ian Douglas Scott <idscott@system76.com>
+Date: Mon, 11 Jan 2021 13:27:15 -0800
+Subject: [PATCH] users: Recreate RunHandler on failure
+
+Workaround for buggy behavior in `run-passwd.c`, which is generally kind
+of a mess.
+---
+ panels/user-accounts/cc-password-dialog.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/panels/user-accounts/cc-password-dialog.c b/panels/user-accounts/cc-password-dialog.c
+index b199999c0..e803ed152 100644
+--- a/panels/user-accounts/cc-password-dialog.c
++++ b/panels/user-accounts/cc-password-dialog.c
+@@ -38,6 +38,13 @@
+ 
+ #define PASSWORD_CHECK_TIMEOUT 600
+ 
++static void
++auth_cb (PasswdHandler    *handler,
++         GError           *error,
++         CcPasswordDialog *self);
++static void
++update_sensitivity (CcPasswordDialog *self);
++
+ struct _CcPasswordDialog
+ {
+         GtkDialog           parent_instance;
+@@ -150,6 +157,14 @@ password_changed_cb (PasswdHandler    *handler,
+                                                   "%s", secondary_text);
+         gtk_dialog_run (GTK_DIALOG (dialog));
+         gtk_widget_destroy (dialog);
++
++        passwd_destroy (self->passwd_handler);
++        self->passwd_handler = passwd_init ();
++        self->old_password_ok = FALSE;
++        clear_entry_validation_error (self->old_password_entry);
++        update_sensitivity (self);
++        const gchar *text = gtk_entry_get_text (self->old_password_entry);
++        passwd_authenticate (self->passwd_handler, text, (PasswdCallback)auth_cb, self);
+ }
+ 
+ static void
+-- 
+2.27.0

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -51,3 +51,4 @@ Revert-user-accounts-Use-custom-setting-to-override-.patch
 0001-Revert-sharing-Remove-vino-preferences.patch
 0002-Revert-sharing-Replace-vino-with-gnome-remote-deskto.patch
 0001-mouse-Add-Disable-While-Typing-toggle-for-touchpad.patch
+0001-Do-not-enforce-password-strength-requirements.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -52,3 +52,4 @@ Revert-user-accounts-Use-custom-setting-to-override-.patch
 0002-Revert-sharing-Replace-vino-with-gnome-remote-deskto.patch
 0001-mouse-Add-Disable-While-Typing-toggle-for-touchpad.patch
 0001-Do-not-enforce-password-strength-requirements.patch
+0002-users-Recreate-RunHandler-on-failure.patch


### PR DESCRIPTION
Gnome Initial Setup doesn't seem to be enforcing this, and since `libpam-pwquality` isn't installed by default, presumably tools like `passwd` aren't.

Perhaps the way Gnome handles this could be done better.