### PR TITLE
groovy: Charge Thresholds

### DIFF
--- a/panels/power/cc-battery-row.c
+++ b/panels/power/cc-battery-row.c
@@ -1,0 +1,279 @@
+/* cc-brightness-scale.c
+ *
+ * Copyright (C) 2010 Red Hat, Inc
+ * Copyright (C) 2008 William Jon McCann <jmccann@redhat.com>
+ * Copyright (C) 2010,2015 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2020 System76, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <glib/gi18n.h>
+
+#include "cc-battery-row.h"
+
+struct _CcBatteryRow {
+  GtkListBoxRow parent_instance;
+
+  GtkBox       *battery_box;
+  GtkLabel     *details_label;
+  GtkImage     *icon;
+  GtkLevelBar  *levelbar;
+  GtkLabel     *name_label;
+  GtkLabel     *percentage_label;
+  GtkBox       *primary_bottom_box;
+  GtkLabel     *primary_percentage_label;
+};
+
+G_DEFINE_TYPE (CcBatteryRow, cc_battery_row, GTK_TYPE_LIST_BOX_ROW)
+
+static void
+cc_battery_row_class_init (CcBatteryRowClass *klass)
+{
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/control-center/power/cc-battery-row.ui");
+
+  gtk_widget_class_bind_template_child (widget_class, CcBatteryRow, battery_box);
+  gtk_widget_class_bind_template_child (widget_class, CcBatteryRow, details_label);
+  gtk_widget_class_bind_template_child (widget_class, CcBatteryRow, icon);
+  gtk_widget_class_bind_template_child (widget_class, CcBatteryRow, levelbar);
+  gtk_widget_class_bind_template_child (widget_class, CcBatteryRow, name_label);
+  gtk_widget_class_bind_template_child (widget_class, CcBatteryRow, percentage_label);
+  gtk_widget_class_bind_template_child (widget_class, CcBatteryRow, primary_bottom_box);
+  gtk_widget_class_bind_template_child (widget_class, CcBatteryRow, primary_percentage_label);
+}
+
+static void
+cc_battery_row_init (CcBatteryRow *self)
+{
+  gtk_widget_init_template (GTK_WIDGET (self));
+}
+
+static gchar *
+get_timestring (guint64 time_secs)
+{
+  gchar* timestring = NULL;
+  gint  hours;
+  gint  minutes;
+
+  /* Add 0.5 to do rounding */
+  minutes = (int) ( ( time_secs / 60.0 ) + 0.5 );
+
+  if (minutes == 0)
+    return g_strdup (_("Unknown time"));
+
+  if (minutes < 60)
+    return timestring = g_strdup_printf (ngettext ("%i minute",
+                                         "%i minutes",
+                                         minutes), minutes);
+
+  hours = minutes / 60;
+  minutes = minutes % 60;
+
+  if (minutes == 0)
+    return timestring = g_strdup_printf (ngettext (
+                                         "%i hour",
+                                         "%i hours",
+                                         hours), hours);
+
+  /* TRANSLATOR: "%i %s %i %s" are "%i hours %i minutes"
+   * Swap order with "%2$s %2$i %1$s %1$i if needed */
+  return timestring = g_strdup_printf (_("%i %s %i %s"),
+                                       hours, ngettext ("hour", "hours", hours),
+                                       minutes, ngettext ("minute", "minutes", minutes));
+}
+
+static gchar *
+get_details_string (gdouble percentage, UpDeviceState state, guint64 time)
+{
+  g_autofree gchar *details = NULL;
+
+  if (time > 0)
+    {
+      g_autofree gchar *time_string = NULL;
+
+      time_string = get_timestring (time);
+      switch (state)
+        {
+          case UP_DEVICE_STATE_CHARGING:
+            /* TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes" */
+            details = g_strdup_printf (_("%s until fully charged"), time_string);
+            break;
+          case UP_DEVICE_STATE_DISCHARGING:
+          case UP_DEVICE_STATE_PENDING_DISCHARGE:
+            if (percentage < 20)
+              {
+                /* TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes" */
+                details = g_strdup_printf (_("Caution: %s remaining"), time_string);
+              }
+            else
+              {
+                /* TRANSLATORS: %1 is a time string, e.g. "1 hour 5 minutes" */
+                details = g_strdup_printf (_("%s remaining"), time_string);
+              }
+            break;
+          case UP_DEVICE_STATE_FULLY_CHARGED:
+            /* TRANSLATORS: primary battery */
+            details = g_strdup (_("Fully charged"));
+            break;
+          case UP_DEVICE_STATE_PENDING_CHARGE:
+            /* TRANSLATORS: primary battery */
+            details = g_strdup (_("Not charging"));
+            break;
+          case UP_DEVICE_STATE_EMPTY:
+            /* TRANSLATORS: primary battery */
+            details = g_strdup (_("Empty"));
+            break;
+          default:
+            details = g_strdup_printf ("error: %s", up_device_state_to_string (state));
+            break;
+        }
+    }
+  else
+    {
+      switch (state)
+        {
+          case UP_DEVICE_STATE_CHARGING:
+            /* TRANSLATORS: primary battery */
+            details = g_strdup (_("Charging"));
+            break;
+          case UP_DEVICE_STATE_DISCHARGING:
+          case UP_DEVICE_STATE_PENDING_DISCHARGE:
+            /* TRANSLATORS: primary battery */
+            details = g_strdup (_("Discharging"));
+            break;
+          case UP_DEVICE_STATE_FULLY_CHARGED:
+            /* TRANSLATORS: primary battery */
+            details = g_strdup (_("Fully charged"));
+            break;
+          case UP_DEVICE_STATE_PENDING_CHARGE:
+            /* TRANSLATORS: primary battery */
+            details = g_strdup (_("Not charging"));
+            break;
+          case UP_DEVICE_STATE_EMPTY:
+            /* TRANSLATORS: primary battery */
+            details = g_strdup (_("Empty"));
+            break;
+          default:
+            details = g_strdup_printf ("error: %s",
+                                       up_device_state_to_string (state));
+            break;
+        }
+    }
+
+  return g_steal_pointer (&details);
+}
+
+CcBatteryRow*
+cc_battery_row_new (UpDevice *device,
+                    gboolean  primary)
+{
+  g_autofree gchar *details = NULL;
+  gdouble percentage;
+  UpDeviceKind kind;
+  UpDeviceState state;
+  g_autofree gchar *s = NULL;
+  g_autofree gchar *icon_name = NULL;
+  const gchar *name;
+  CcBatteryRow *self;
+  guint64 time_empty, time_full, time;
+  gdouble energy_full, energy_rate;
+
+  self = g_object_new (CC_TYPE_BATTERY_ROW, NULL);
+
+  g_object_get (device,
+                "kind", &kind,
+                "state", &state,
+                "percentage", &percentage,
+                "icon-name", &icon_name,
+                "time-to-empty", &time_empty,
+                "time-to-full", &time_full,
+                "energy-full", &energy_full,
+                "energy-rate", &energy_rate,
+                NULL);
+  if (state == UP_DEVICE_STATE_DISCHARGING)
+    time = time_empty;
+  else
+    time = time_full;
+
+  /* Name label */
+  if (g_object_get_data (G_OBJECT (device), "is-main-battery") != NULL)
+    name = C_("Battery name", "Main");
+  else
+    name = C_("Battery name", "Extra");
+  gtk_label_set_text (self->name_label, name);
+
+  /* Icon */
+  if (icon_name != NULL && *icon_name != '\0')
+    gtk_image_set_from_icon_name (self->icon, icon_name, GTK_ICON_SIZE_BUTTON);
+
+  /* Percentage label */
+  s = g_strdup_printf ("%d%%", (int)percentage);
+  gtk_label_set_text (self->percentage_label, s);
+  gtk_label_set_text (self->primary_percentage_label, s);
+
+  /* Level bar */
+  gtk_level_bar_set_value (self->levelbar, percentage / 100.0);
+
+  /* Details label (primary only) */
+  details = get_details_string (percentage, state, time);
+  gtk_label_set_text (self->details_label, details);
+
+  /* Handle "primary" row differently */
+  gtk_widget_set_visible (GTK_WIDGET (self->battery_box), !primary);
+  gtk_widget_set_visible (GTK_WIDGET (self->percentage_label), !primary);
+  gtk_widget_set_visible (GTK_WIDGET (self->primary_bottom_box), primary);
+  atk_object_add_relationship (gtk_widget_get_accessible (GTK_WIDGET (self->levelbar)),
+                               ATK_RELATION_LABELLED_BY,
+                               gtk_widget_get_accessible (GTK_WIDGET (primary ? self->primary_percentage_label
+                                                                              : self->percentage_label)));
+  g_object_set_data (G_OBJECT (self), "primary", GINT_TO_POINTER (primary));
+
+  g_object_set_data (G_OBJECT (self), "kind", GINT_TO_POINTER (kind));
+
+  return self;
+}
+
+
+
+void
+cc_battery_row_set_level_sizegroup (CcBatteryRow *self,
+                                    GtkSizeGroup *sizegroup)
+{
+  gtk_size_group_add_widget (sizegroup, GTK_WIDGET (self->levelbar));
+}
+
+void
+cc_battery_row_set_row_sizegroup (CcBatteryRow *self,
+                                  GtkSizeGroup *sizegroup)
+{
+  gtk_size_group_add_widget (sizegroup, GTK_WIDGET (self));
+}
+
+void
+cc_battery_row_set_charge_sizegroup (CcBatteryRow *self,
+                                     GtkSizeGroup *sizegroup)
+{
+  gtk_size_group_add_widget (sizegroup, GTK_WIDGET (self->percentage_label));
+}
+
+void
+cc_battery_row_set_battery_sizegroup (CcBatteryRow *self,
+                                      GtkSizeGroup *sizegroup)
+{
+  gtk_size_group_add_widget (sizegroup, GTK_WIDGET (self->battery_box));
+}

--- a/panels/power/cc-battery-row.h
+++ b/panels/power/cc-battery-row.h
@@ -1,0 +1,46 @@
+/* cc-brightness-scale.h
+ *
+ * Copyright (C) 2020 System76, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+#include <libupower-glib/upower.h>
+
+G_BEGIN_DECLS
+
+#define CC_TYPE_BATTERY_ROW (cc_battery_row_get_type())
+G_DECLARE_FINAL_TYPE (CcBatteryRow, cc_battery_row, CC, BATTERY_ROW, GtkListBoxRow)
+
+CcBatteryRow* cc_battery_row_new                    (UpDevice *device,
+                                                     gboolean  primary);
+
+void          cc_battery_row_set_level_sizegroup     (CcBatteryRow *self,
+                                                      GtkSizeGroup *sizegroup);
+
+void          cc_battery_row_set_row_sizegroup       (CcBatteryRow *self,
+                                                      GtkSizeGroup *sizegroup);
+
+void          cc_battery_row_set_charge_sizegroup    (CcBatteryRow *self,
+                                                      GtkSizeGroup *sizegroup);
+
+void          cc_battery_row_set_battery_sizegroup   (CcBatteryRow *self,
+                                                      GtkSizeGroup *sizegroup);
+
+G_END_DECLS

--- a/panels/power/cc-battery-row.h
+++ b/panels/power/cc-battery-row.h
@@ -43,4 +43,7 @@ void          cc_battery_row_set_charge_sizegroup    (CcBatteryRow *self,
 void          cc_battery_row_set_battery_sizegroup   (CcBatteryRow *self,
                                                       GtkSizeGroup *sizegroup);
 
+gboolean      cc_battery_row_get_primary             (CcBatteryRow *self);
+UpDeviceKind  cc_battery_row_get_kind                (CcBatteryRow *self);
+
 G_END_DECLS

--- a/panels/power/cc-battery-row.ui
+++ b/panels/power/cc-battery-row.ui
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <!-- interface-requires gtk+ 3.0 -->
+  <template class="CcBatteryRow" parent="GtkListBoxRow">
+    <property name="visible">True</property>
+    <property name="selectable">False</property>
+    <property name="activatable">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="orientation">vertical</property>
+        <property name="valign">center</property>
+        <property name="margin-start">12</property>
+        <property name="margin-end">12</property>
+        <property name="margin-top">16</property>
+        <property name="margin-bottom">14</property>
+        <property name="spacing">10</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="orientation">horizontal</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkBox" id="battery_box">
+                <property name="visible">True</property>
+                <property name="orientation">horizontal</property>
+                <property name="spacing">12</property>
+                <child>
+                  <object class="GtkLabel" id="name_label">
+                    <property name="visible">True</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkImage" id="icon">
+                    <property name="visible">True</property>
+                    <property name="halign">end</property>
+                    <property name="valign">center</property>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="pack-type">end</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="percentage_label">
+                <property name="visible">True</property>
+                    <property name="halign">end</property>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLevelBar" id="levelbar">
+                <property name="visible">True</property>
+                <property name="hexpand">True</property>
+                <property name="halign">fill</property>
+                <property name="valign">center</property>
+                <offsets>
+                  <offset name="warning-battery-offset" value="0.03"/>
+                  <offset name="low-battery-offset" value="0.1"/>
+                  <offset name="high-battery-offset" value="1.0"/>
+                </offsets>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox" id="primary_bottom_box">
+            <property name="visible">True</property>
+            <property name="orientation">horizontal</property>
+            <child>
+              <object class="GtkLabel" id="details_label">
+                <property name="visible">True</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="primary_percentage_label">
+                <property name="visible">True</property>
+              </object>
+              <packing>
+                <property name="pack-type">end</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>
+

--- a/panels/power/cc-charge-threshold-dialog.c
+++ b/panels/power/cc-charge-threshold-dialog.c
@@ -1,0 +1,194 @@
+#include "cc-charge-threshold-dialog.h"
+#include "cc-charge-threshold-row.h"
+#include "list-box-helper.h"
+
+ChargeProfile charge_profile_from_thresholds (guchar start, guchar end) {
+  if (start == 50 && end == 60)
+    return CHARGE_PROFILE_MAX_LIFESPAN;
+  else if (start == 85 && end == 90)
+    return CHARGE_PROFILE_BALANCED;
+  else if (start == 96 && end == 100)
+    return CHARGE_PROFILE_FULL_CHARGE;
+  else
+    return CHARGE_PROFILE_UNDEFINED;
+}
+
+void charge_profile_get_thresholds (ChargeProfile profile, guchar *start, guchar *end) {
+  switch (profile) {
+    case CHARGE_PROFILE_MAX_LIFESPAN:
+      *start = 50;
+      *end = 60;
+      break;
+    case CHARGE_PROFILE_BALANCED:
+      *start = 85;
+      *end = 90;
+      break;
+    case CHARGE_PROFILE_FULL_CHARGE:
+    default:
+      *start = 96;
+      *end = 100;
+      break;
+  }
+}
+
+gchar *charge_profile_title_from_thresholds (guchar start, guchar end) {
+  switch (charge_profile_from_thresholds (start, end)) {
+    case CHARGE_PROFILE_MAX_LIFESPAN:
+      return g_strdup ("Max lifespan");
+    case CHARGE_PROFILE_BALANCED:
+      return g_strdup ("Balanced");
+    case CHARGE_PROFILE_FULL_CHARGE:
+      return g_strdup ("Full Charge");
+    default:
+      return g_strdup_printf ("Custom (%d%% - %d%%)", start, end);
+  }
+}
+
+struct _CcChargeThresholdDialog {
+  GtkDialog parent_instance;
+
+  S76PowerDaemon *power_proxy;
+  GtkScale *scale;
+  GtkListBox *listbox;
+  GtkListBoxRow *max_lifespan_row;
+  GtkListBoxRow *balanced_row;
+  GtkListBoxRow *full_charge_row;
+  GtkRadioButton *max_lifespan_radio;
+  GtkRadioButton *balanced_radio;
+  GtkRadioButton *full_charge_radio;
+  GtkRadioButton *previous_radio;
+  GtkRadioButton *hidden_radio;
+};
+
+G_DEFINE_TYPE (CcChargeThresholdDialog, cc_charge_threshold_dialog, GTK_TYPE_DIALOG)
+
+static void radio_toggled_cb (CcChargeThresholdDialog *self, GtkRadioButton *radio);
+
+static void
+set_charge_thresholds_ready(GObject *source_object,
+                            GAsyncResult *res,
+                            gpointer user_data) {
+  g_autoptr(GError) error = NULL;
+  CcChargeThresholdDialog *self = CC_CHARGE_THRESHOLD_DIALOG (user_data);
+  GtkRadioButton *previous_radio = self->previous_radio;
+
+  s76_power_daemon_call_set_charge_thresholds_finish (self->power_proxy, res, &error);
+  if (error) {
+    g_signal_handlers_block_by_func (previous_radio, radio_toggled_cb, self);
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (previous_radio), TRUE);
+    g_signal_handlers_unblock_by_func (previous_radio, radio_toggled_cb, self);
+
+    if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+      g_warning ("Failed to call set-charge-thresholds: %s", error->message);
+    return;
+  }
+}
+
+static void
+radio_toggled_cb (CcChargeThresholdDialog *self, GtkRadioButton *radio)
+{
+  ChargeProfile profile;
+  guchar start, end;
+  GVariant *thresholds = NULL;
+  gboolean state = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (radio));
+
+  if (!state)
+    {
+      self->previous_radio = radio;
+      return;
+    }
+
+  if (radio == self->max_lifespan_radio)
+    profile = CHARGE_PROFILE_MAX_LIFESPAN;
+  else if (radio == self->balanced_radio)
+    profile = CHARGE_PROFILE_BALANCED;
+  else if (radio == self->full_charge_radio)
+    profile = CHARGE_PROFILE_FULL_CHARGE;
+  else
+    return;
+
+  charge_profile_get_thresholds (profile, &start, &end);
+  thresholds = g_variant_new ("(yy)", start, end);
+
+  s76_power_daemon_call_set_charge_thresholds (self->power_proxy, thresholds, NULL, set_charge_thresholds_ready, self);
+}
+
+static void
+row_activated_cb (CcChargeThresholdDialog *self, GtkListBoxRow *row)
+{
+  if (row == self->max_lifespan_row)
+    gtk_button_clicked (GTK_BUTTON (self->max_lifespan_radio));
+  else if (row == self->balanced_row)
+    gtk_button_clicked (GTK_BUTTON (self->balanced_radio));
+  else if (row == self->full_charge_row)
+    gtk_button_clicked (GTK_BUTTON (self->full_charge_radio));
+}
+
+static void
+cc_charge_threshold_dialog_class_init (CcChargeThresholdDialogClass *klass)
+{
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  g_type_ensure (CC_TYPE_CHARGE_THRESHOLD_ROW);
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/control-center/power/cc-charge-threshold-dialog.ui");
+
+  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, listbox);
+  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, max_lifespan_row);
+  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, balanced_row);
+  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, full_charge_row);
+  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, max_lifespan_radio);
+  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, balanced_radio);
+  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, full_charge_radio);
+  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, hidden_radio);
+
+  gtk_widget_class_bind_template_callback (widget_class, radio_toggled_cb);
+  gtk_widget_class_bind_template_callback (widget_class, row_activated_cb);
+}
+
+static void
+cc_charge_threshold_dialog_init (CcChargeThresholdDialog *self)
+{
+  gtk_widget_init_template (GTK_WIDGET (self));
+
+  self->power_proxy = NULL;
+
+  gtk_list_box_set_header_func (self->listbox, cc_list_box_update_header_func, NULL, NULL);
+}
+
+CcChargeThresholdDialog*
+cc_charge_threshold_dialog_new (S76PowerDaemon *power_proxy, ChargeProfile profile)
+{
+  GtkRadioButton *radio = NULL;
+  CcChargeThresholdDialog *dialog = g_object_new (CC_TYPE_CHARGE_THRESHOLD_DIALOG,
+                                                  "use-header-bar", 1,
+                                                  NULL);
+  dialog->power_proxy = power_proxy;
+
+  switch (profile) {
+    case CHARGE_PROFILE_MAX_LIFESPAN:
+      radio = dialog->max_lifespan_radio;
+      break;
+    case CHARGE_PROFILE_BALANCED:
+      radio = dialog->balanced_radio;
+      break;
+    case CHARGE_PROFILE_FULL_CHARGE:
+      radio = dialog->full_charge_radio;
+      break;
+    default:
+      break;
+  }
+
+  if (radio)
+    {
+      g_signal_handlers_block_by_func (radio, radio_toggled_cb, dialog);
+      gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (radio), TRUE);
+      g_signal_handlers_unblock_by_func (radio, radio_toggled_cb, dialog);
+    }
+  else
+    {
+      gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (dialog->hidden_radio), TRUE);
+    }
+
+  return dialog;
+}

--- a/panels/power/cc-charge-threshold-dialog.c
+++ b/panels/power/cc-charge-threshold-dialog.c
@@ -1,48 +1,5 @@
 #include "cc-charge-threshold-dialog.h"
-#include "cc-charge-threshold-row.h"
 #include "list-box-helper.h"
-
-ChargeProfile charge_profile_from_thresholds (guchar start, guchar end) {
-  if (start == 50 && end == 60)
-    return CHARGE_PROFILE_MAX_LIFESPAN;
-  else if (start == 85 && end == 90)
-    return CHARGE_PROFILE_BALANCED;
-  else if (start == 96 && end == 100)
-    return CHARGE_PROFILE_FULL_CHARGE;
-  else
-    return CHARGE_PROFILE_UNDEFINED;
-}
-
-void charge_profile_get_thresholds (ChargeProfile profile, guchar *start, guchar *end) {
-  switch (profile) {
-    case CHARGE_PROFILE_MAX_LIFESPAN:
-      *start = 50;
-      *end = 60;
-      break;
-    case CHARGE_PROFILE_BALANCED:
-      *start = 85;
-      *end = 90;
-      break;
-    case CHARGE_PROFILE_FULL_CHARGE:
-    default:
-      *start = 96;
-      *end = 100;
-      break;
-  }
-}
-
-gchar *charge_profile_title_from_thresholds (guchar start, guchar end) {
-  switch (charge_profile_from_thresholds (start, end)) {
-    case CHARGE_PROFILE_MAX_LIFESPAN:
-      return g_strdup ("Max lifespan");
-    case CHARGE_PROFILE_BALANCED:
-      return g_strdup ("Balanced");
-    case CHARGE_PROFILE_FULL_CHARGE:
-      return g_strdup ("Full Charge");
-    default:
-      return g_strdup_printf ("Custom (%d%% - %d%%)", start, end);
-  }
-}
 
 struct _CcChargeThresholdDialog {
   GtkDialog parent_instance;
@@ -50,14 +7,8 @@ struct _CcChargeThresholdDialog {
   S76PowerDaemon *power_proxy;
   GtkScale *scale;
   GtkListBox *listbox;
-  GtkListBoxRow *max_lifespan_row;
-  GtkListBoxRow *balanced_row;
-  GtkListBoxRow *full_charge_row;
-  GtkRadioButton *max_lifespan_radio;
-  GtkRadioButton *balanced_radio;
-  GtkRadioButton *full_charge_radio;
-  GtkRadioButton *previous_radio;
   GtkRadioButton *hidden_radio;
+  GtkRadioButton *previous_radio;
 };
 
 G_DEFINE_TYPE (CcChargeThresholdDialog, cc_charge_threshold_dialog, GTK_TYPE_DIALOG)
@@ -87,9 +38,9 @@ set_charge_thresholds_ready(GObject *source_object,
 static void
 radio_toggled_cb (CcChargeThresholdDialog *self, GtkRadioButton *radio)
 {
-  ChargeProfile profile;
-  guchar start, end;
+  ChargeProfile *profile;
   GVariant *thresholds = NULL;
+  GtkWidget *row;
   gboolean state = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (radio));
 
   if (!state)
@@ -98,17 +49,12 @@ radio_toggled_cb (CcChargeThresholdDialog *self, GtkRadioButton *radio)
       return;
     }
 
-  if (radio == self->max_lifespan_radio)
-    profile = CHARGE_PROFILE_MAX_LIFESPAN;
-  else if (radio == self->balanced_radio)
-    profile = CHARGE_PROFILE_BALANCED;
-  else if (radio == self->full_charge_radio)
-    profile = CHARGE_PROFILE_FULL_CHARGE;
-  else
+  row = gtk_widget_get_ancestor (GTK_WIDGET (radio), CC_TYPE_CHARGE_THRESHOLD_ROW);
+  if (row == NULL)
     return;
 
-  charge_profile_get_thresholds (profile, &start, &end);
-  thresholds = g_variant_new ("(yy)", start, end);
+  profile = cc_charge_threshold_row_get_profile (CC_CHARGE_THRESHOLD_ROW (row));
+  thresholds = g_variant_new ("(yy)", profile->start, profile->end);
 
   s76_power_daemon_call_set_charge_thresholds (self->power_proxy, thresholds, NULL, set_charge_thresholds_ready, self);
 }
@@ -116,12 +62,9 @@ radio_toggled_cb (CcChargeThresholdDialog *self, GtkRadioButton *radio)
 static void
 row_activated_cb (CcChargeThresholdDialog *self, GtkListBoxRow *row)
 {
-  if (row == self->max_lifespan_row)
-    gtk_button_clicked (GTK_BUTTON (self->max_lifespan_radio));
-  else if (row == self->balanced_row)
-    gtk_button_clicked (GTK_BUTTON (self->balanced_radio));
-  else if (row == self->full_charge_row)
-    gtk_button_clicked (GTK_BUTTON (self->full_charge_radio));
+  CcChargeThresholdRow *profile_row = CC_CHARGE_THRESHOLD_ROW (row);
+  GtkRadioButton *radio = cc_charge_threshold_row_get_radio (profile_row);
+  gtk_button_clicked (GTK_BUTTON (radio));
 }
 
 static void
@@ -134,12 +77,6 @@ cc_charge_threshold_dialog_class_init (CcChargeThresholdDialogClass *klass)
   gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/control-center/power/cc-charge-threshold-dialog.ui");
 
   gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, listbox);
-  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, max_lifespan_row);
-  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, balanced_row);
-  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, full_charge_row);
-  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, max_lifespan_radio);
-  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, balanced_radio);
-  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, full_charge_radio);
   gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdDialog, hidden_radio);
 
   gtk_widget_class_bind_template_callback (widget_class, radio_toggled_cb);
@@ -157,33 +94,32 @@ cc_charge_threshold_dialog_init (CcChargeThresholdDialog *self)
 }
 
 CcChargeThresholdDialog*
-cc_charge_threshold_dialog_new (S76PowerDaemon *power_proxy, ChargeProfile profile)
+cc_charge_threshold_dialog_new (S76PowerDaemon *power_proxy, ChargeProfile **profiles, ChargeProfile *profile)
 {
-  GtkRadioButton *radio = NULL;
+  GtkRadioButton *selected_radio = NULL;
   CcChargeThresholdDialog *dialog = g_object_new (CC_TYPE_CHARGE_THRESHOLD_DIALOG,
                                                   "use-header-bar", 1,
                                                   NULL);
   dialog->power_proxy = power_proxy;
 
-  switch (profile) {
-    case CHARGE_PROFILE_MAX_LIFESPAN:
-      radio = dialog->max_lifespan_radio;
-      break;
-    case CHARGE_PROFILE_BALANCED:
-      radio = dialog->balanced_radio;
-      break;
-    case CHARGE_PROFILE_FULL_CHARGE:
-      radio = dialog->full_charge_radio;
-      break;
-    default:
-      break;
-  }
-
-  if (radio)
+  for (int i = 0; profiles[i] != NULL; i++)
     {
-      g_signal_handlers_block_by_func (radio, radio_toggled_cb, dialog);
-      gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (radio), TRUE);
-      g_signal_handlers_unblock_by_func (radio, radio_toggled_cb, dialog);
+      CcChargeThresholdRow *row = cc_charge_threshold_row_new (profiles[i]);
+      gtk_container_add (GTK_CONTAINER (dialog->listbox), GTK_WIDGET (row));
+
+      GtkRadioButton *radio = cc_charge_threshold_row_get_radio (row);
+      gtk_radio_button_join_group (radio, dialog->hidden_radio);
+      g_signal_connect_object (radio, "toggled", G_CALLBACK (radio_toggled_cb), dialog, G_CONNECT_SWAPPED);
+
+      if (profiles[i] == profile)
+        selected_radio = radio;
+    }
+
+  if (selected_radio)
+    {
+      g_signal_handlers_block_by_func (selected_radio, radio_toggled_cb, dialog);
+      gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (selected_radio), TRUE);
+      g_signal_handlers_unblock_by_func (selected_radio, radio_toggled_cb, dialog);
     }
   else
     {

--- a/panels/power/cc-charge-threshold-dialog.h
+++ b/panels/power/cc-charge-threshold-dialog.h
@@ -28,6 +28,6 @@ G_BEGIN_DECLS
 
 #define CC_TYPE_CHARGE_THRESHOLD_DIALOG (cc_charge_threshold_dialog_get_type())
 G_DECLARE_FINAL_TYPE (CcChargeThresholdDialog, cc_charge_threshold_dialog, CC, CHARGE_THRESHOLD_DIALOG, GtkDialog)
-CcChargeThresholdDialog* cc_charge_threshold_dialog_new (S76PowerDaemon *power_proxy, ChargeProfile **profiles, ChargeProfile *profile);
+CcChargeThresholdDialog* cc_charge_threshold_dialog_new (S76PowerDaemon *power_proxy, ChargeProfile **profiles, guint start, guint end);
 
 G_END_DECLS

--- a/panels/power/cc-charge-threshold-dialog.h
+++ b/panels/power/cc-charge-threshold-dialog.h
@@ -22,21 +22,12 @@
 
 #include <gtk/gtk.h>
 #include "cc-system76-power-generated.h"
+#include "cc-charge-threshold-row.h"
 
 G_BEGIN_DECLS
 
-typedef enum {
-  CHARGE_PROFILE_MAX_LIFESPAN,
-  CHARGE_PROFILE_BALANCED,
-  CHARGE_PROFILE_FULL_CHARGE,
-  CHARGE_PROFILE_UNDEFINED,
-} ChargeProfile;
-
 #define CC_TYPE_CHARGE_THRESHOLD_DIALOG (cc_charge_threshold_dialog_get_type())
 G_DECLARE_FINAL_TYPE (CcChargeThresholdDialog, cc_charge_threshold_dialog, CC, CHARGE_THRESHOLD_DIALOG, GtkDialog)
-CcChargeThresholdDialog* cc_charge_threshold_dialog_new (S76PowerDaemon *power_proxy, ChargeProfile profile);
-ChargeProfile charge_profile_from_thresholds (guchar start, guchar end);
-void charge_profile_get_thresholds (ChargeProfile profile, guchar *start, guchar *end);
-gchar *charge_profile_title_from_thresholds (guchar start, guchar end);
+CcChargeThresholdDialog* cc_charge_threshold_dialog_new (S76PowerDaemon *power_proxy, ChargeProfile **profiles, ChargeProfile *profile);
 
 G_END_DECLS

--- a/panels/power/cc-charge-threshold-dialog.h
+++ b/panels/power/cc-charge-threshold-dialog.h
@@ -1,0 +1,42 @@
+/* cc-brightness-scale.h
+ *
+ * Copyright (C) 2020 System76, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+#include "cc-system76-power-generated.h"
+
+G_BEGIN_DECLS
+
+typedef enum {
+  CHARGE_PROFILE_MAX_LIFESPAN,
+  CHARGE_PROFILE_BALANCED,
+  CHARGE_PROFILE_FULL_CHARGE,
+  CHARGE_PROFILE_UNDEFINED,
+} ChargeProfile;
+
+#define CC_TYPE_CHARGE_THRESHOLD_DIALOG (cc_charge_threshold_dialog_get_type())
+G_DECLARE_FINAL_TYPE (CcChargeThresholdDialog, cc_charge_threshold_dialog, CC, CHARGE_THRESHOLD_DIALOG, GtkDialog)
+CcChargeThresholdDialog* cc_charge_threshold_dialog_new (S76PowerDaemon *power_proxy, ChargeProfile profile);
+ChargeProfile charge_profile_from_thresholds (guchar start, guchar end);
+void charge_profile_get_thresholds (ChargeProfile profile, guchar *start, guchar *end);
+gchar *charge_profile_title_from_thresholds (guchar start, guchar end);
+
+G_END_DECLS

--- a/panels/power/cc-charge-threshold-dialog.ui
+++ b/panels/power/cc-charge-threshold-dialog.ui
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <!-- interface-requires gtk+ 3.0 -->
+  <template class="CcChargeThresholdDialog" parent="GtkDialog">
+    <property name="modal">True</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="margin">15</property>
+        <property name="spacing">15</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="halign">start</property>
+            <property name="wrap">True</property>
+            <property name="width-chars">70</property>
+            <property name="max-width-chars">70</property>
+            <property name="label">Increase the lifespan of your battery by setting a maximum charge value below 100%.</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFrame">
+            <property name="visible">True</property>
+            <child>
+              <object class="GtkListBox" id="listbox">
+                <property name="visible">True</property>
+                <property name="selection-mode">GTK_SELECTION_BROWSE</property>
+                <signal name="row-activated" handler="row_activated_cb" object="CcChargeThresholdDialog" swapped="yes" />
+                <child>
+                  <object class="CcChargeThresholdRow" id="full_charge_row">
+                    <property name="visible">True</property>
+                    <property name="title">Full Charge (100%)</property>
+                    <property name="description">Battery is charged to its full capacity for the longest possible use on battery power. Charging resumes when the battery falls below 96% charge.</property>
+                    <child internal-child="radio">
+                      <object class="GtkRadioButton" id="full_charge_radio">
+                        <property name="group">max_lifespan_radio</property>
+                        <signal name="toggled" handler="radio_toggled_cb" object="CcChargeThresholdDialog" swapped="yes" />
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="CcChargeThresholdRow" id="balanced_row">
+                    <property name="visible">True</property>
+                    <property name="title">Balanced (90%)</property>
+                    <property name="description">Use this threshold when you unplug frequently but don't need the full battery capacity. Charging stops when the battery reaches 90% capacity and resumes when the battery falls below 85%.</property>
+                    <child internal-child="radio">
+                      <object class="GtkRadioButton" id="balanced_radio">
+                        <property name="group">max_lifespan_radio</property>
+                        <signal name="toggled" handler="radio_toggled_cb" object="CcChargeThresholdDialog" swapped="yes" />
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="CcChargeThresholdRow" id="max_lifespan_row">
+                    <property name="visible">True</property>
+                    <property name="title">Maximum Lifespan (60%)</property>
+                    <property name="description">Use this threshold if you rarely use the system on battery for extended periods. Charging stops when the battery reaches 60% capacity and resumes when the battery falls below 50%.</property>
+                    <child internal-child="radio">
+                      <object class="GtkRadioButton" id="max_lifespan_radio">
+                        <property name="group">max_lifespan_radio</property>
+                        <signal name="toggled" handler="radio_toggled_cb" object="CcChargeThresholdDialog" swapped="yes" />
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <!-- Hack to show no radio button selected when profile is undefined -->
+          <object class="GtkRadioButton" id="hidden_radio">
+            <property name="visible">False</property>
+            <property name="group">max_lifespan_radio</property>
+            <signal name="toggled" handler="radio_toggled_cb" object="CcChargeThresholdDialog" swapped="yes" />
+          </object>
+        </child>
+      </object>
+    </child>
+    <child internal-child="headerbar">
+      <object class="GtkHeaderBar">
+        <property name="title">Battery Charge Thresholds</property>
+        <property name="can_focus">False</property>
+        <property name="show_close_button">True</property>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/panels/power/cc-charge-threshold-dialog.ui
+++ b/panels/power/cc-charge-threshold-dialog.ui
@@ -12,6 +12,7 @@
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="halign">start</property>
+            <property name="xalign">0</property>
             <property name="wrap">True</property>
             <property name="width-chars">70</property>
             <property name="max-width-chars">70</property>
@@ -28,6 +29,19 @@
                 <signal name="row-activated" handler="row_activated_cb" object="CcChargeThresholdDialog" swapped="yes" />
               </object>
             </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="custom_label">
+            <property name="visible" bind-source="hidden_radio" bind-property="active" bind-flags="sync-create" />
+            <property name="xalign">0</property>
+            <property name="halign">start</property>
+            <property name="wrap">True</property>
+            <property name="width-chars">70</property>
+            <property name="max-width-chars">70</property>
+            <attributes>
+              <attribute name="weight" value="PANGO_WEIGHT_BOLD"/>
+            </attributes>
           </object>
         </child>
         <child>

--- a/panels/power/cc-charge-threshold-dialog.ui
+++ b/panels/power/cc-charge-threshold-dialog.ui
@@ -26,45 +26,6 @@
                 <property name="visible">True</property>
                 <property name="selection-mode">GTK_SELECTION_BROWSE</property>
                 <signal name="row-activated" handler="row_activated_cb" object="CcChargeThresholdDialog" swapped="yes" />
-                <child>
-                  <object class="CcChargeThresholdRow" id="full_charge_row">
-                    <property name="visible">True</property>
-                    <property name="title">Full Charge (100%)</property>
-                    <property name="description">Battery is charged to its full capacity for the longest possible use on battery power. Charging resumes when the battery falls below 96% charge.</property>
-                    <child internal-child="radio">
-                      <object class="GtkRadioButton" id="full_charge_radio">
-                        <property name="group">max_lifespan_radio</property>
-                        <signal name="toggled" handler="radio_toggled_cb" object="CcChargeThresholdDialog" swapped="yes" />
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="CcChargeThresholdRow" id="balanced_row">
-                    <property name="visible">True</property>
-                    <property name="title">Balanced (90%)</property>
-                    <property name="description">Use this threshold when you unplug frequently but don't need the full battery capacity. Charging stops when the battery reaches 90% capacity and resumes when the battery falls below 85%.</property>
-                    <child internal-child="radio">
-                      <object class="GtkRadioButton" id="balanced_radio">
-                        <property name="group">max_lifespan_radio</property>
-                        <signal name="toggled" handler="radio_toggled_cb" object="CcChargeThresholdDialog" swapped="yes" />
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="CcChargeThresholdRow" id="max_lifespan_row">
-                    <property name="visible">True</property>
-                    <property name="title">Maximum Lifespan (60%)</property>
-                    <property name="description">Use this threshold if you rarely use the system on battery for extended periods. Charging stops when the battery reaches 60% capacity and resumes when the battery falls below 50%.</property>
-                    <child internal-child="radio">
-                      <object class="GtkRadioButton" id="max_lifespan_radio">
-                        <property name="group">max_lifespan_radio</property>
-                        <signal name="toggled" handler="radio_toggled_cb" object="CcChargeThresholdDialog" swapped="yes" />
-                      </object>
-                    </child>
-                  </object>
-                </child>
               </object>
             </child>
           </object>
@@ -73,7 +34,6 @@
           <!-- Hack to show no radio button selected when profile is undefined -->
           <object class="GtkRadioButton" id="hidden_radio">
             <property name="visible">False</property>
-            <property name="group">max_lifespan_radio</property>
             <signal name="toggled" handler="radio_toggled_cb" object="CcChargeThresholdDialog" swapped="yes" />
           </object>
         </child>

--- a/panels/power/cc-charge-threshold-row.c
+++ b/panels/power/cc-charge-threshold-row.c
@@ -3,103 +3,111 @@
 struct _CcChargeThresholdRow {
   GtkListBoxRow parent_instance;
   GtkRadioButton *radio;
-  char *title;
-  char *description;
+  ChargeProfile *profile;
+  GtkLabel *title_label;
+  GtkLabel *description_label;
 };
 
 G_DEFINE_TYPE (CcChargeThresholdRow, cc_charge_threshold_row, GTK_TYPE_LIST_BOX_ROW)
 
-enum
+ChargeProfile *charge_profiles_get (ChargeProfile **profiles, guchar start, guchar end)
 {
-  PROP_0,
-  PROP_TITLE,
-  PROP_DESCRIPTION,
-  PROP_LAST
-};
-
-static void
-finalize (GObject *object)
-{
-  CcChargeThresholdRow *self = CC_CHARGE_THRESHOLD_ROW (object);
-  g_free (self->title);
-  g_free (self->description);
+  for (int i = 0; profiles[i] != NULL; i++)
+    if (profiles[i]->start == start && profiles[i]->end == end)
+      return profiles[i];
+  return NULL;
 }
 
-static void
-set_property (GObject      *object,
-              guint         prop_id,
-              const GValue *value,
-              GParamSpec   *pspec)
+ChargeProfile **charge_profiles_from_variant (GVariant *variant)
 {
-  CcChargeThresholdRow *self = CC_CHARGE_THRESHOLD_ROW (object);
+  GVariantIter iter;
+  GVariant *dict;
+  ChargeProfile **profiles;
+  int i = 0;
+  gchar *id, *title, *description;
 
-  switch (prop_id) {
-  case PROP_TITLE:
-    self->title = g_value_dup_string (value);
-    break;
-  case PROP_DESCRIPTION:
-    self->description = g_value_dup_string (value);
-    break;
-  default:
-    G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    break;
-  }
+  profiles = g_malloc ((g_variant_n_children (variant) + 1) * sizeof (ChargeProfile*));
+
+  g_variant_iter_init (&iter, variant);
+  while ((dict = g_variant_iter_next_value (&iter)))
+    {
+      ChargeProfile *profile = g_malloc(sizeof (ChargeProfile));
+
+      gboolean success = TRUE;
+      success = success && g_variant_lookup (dict, "id", "s", &id);
+      success = success && g_variant_lookup (dict, "title", "s", &title);
+      success = success && g_variant_lookup (dict, "description", "s", &description);
+      success = success && g_variant_lookup (dict, "start", "y", &profile->start);
+      success = success && g_variant_lookup (dict, "end", "y", &profile->end);
+
+      if (success)
+        {
+          profile->id = g_strdup(id);
+          profile->title = g_strdup(title);
+          profile->description = g_strdup(description);
+          profiles[i++] = profile;
+        }
+      else
+        {
+          g_warning ("Failed to parse charge profile");
+          g_free (profile);
+        }
+    }
+  profiles[i] = NULL;
+
+  return profiles;
 }
 
-static void
-get_property (GObject    *object,
-              guint       prop_id,
-              GValue     *value,
-              GParamSpec *pspec)
+void charge_profiles_free (ChargeProfile **profiles)
 {
-  CcChargeThresholdRow *self = CC_CHARGE_THRESHOLD_ROW (object);
-
-  switch (prop_id) {
-  case PROP_TITLE:
-    g_value_set_string (value, self->title);
-    break;
-  case PROP_DESCRIPTION:
-    g_value_set_string (value, self->description);
-    break;
-  default:
-    G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
-    break;
-  }
+  for (int i = 0; profiles[i] != NULL; i++)
+    {
+      g_free (profiles[i]->id);
+      g_free (profiles[i]->title);
+      g_free (profiles[i]->description);
+      g_free (profiles[i]);
+    }
+  g_free (profiles);
 }
 
 static void
 cc_charge_threshold_row_class_init (CcChargeThresholdRowClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
-  object_class->set_property = set_property;
-  object_class->get_property = get_property;
-  object_class->finalize = finalize;
-
-  g_object_class_install_property (object_class,
-                                   PROP_TITLE,
-                                   g_param_spec_string ("title",
-                                                        "title",
-                                                        "title",
-                                                        NULL,
-                                                        G_PARAM_READWRITE));
-
-  g_object_class_install_property (object_class,
-                                   PROP_DESCRIPTION,
-                                   g_param_spec_string ("description",
-                                                        "description",
-                                                        "description",
-                                                        NULL,
-                                                        G_PARAM_READWRITE));
-
   gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/control-center/power/cc-charge-threshold-row.ui");
+  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdRow, radio);
+  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdRow, title_label);
+  gtk_widget_class_bind_template_child (widget_class, CcChargeThresholdRow, description_label);
+}
 
-  gtk_widget_class_bind_template_child_internal (widget_class, CcChargeThresholdRow, radio);
+CcChargeThresholdRow*
+cc_charge_threshold_row_new (ChargeProfile *profile)
+{
+  CcChargeThresholdRow *row;
+
+  row = g_object_new(CC_TYPE_CHARGE_THRESHOLD_ROW, NULL);
+  row->profile = profile;
+  gtk_label_set_text (row->title_label, profile->title);
+  gtk_label_set_text (row->description_label, profile->description);
+
+  return row;
 }
 
 static void
 cc_charge_threshold_row_init (CcChargeThresholdRow *self)
 {
   gtk_widget_init_template (GTK_WIDGET (self));
+}
+
+GtkRadioButton*
+cc_charge_threshold_row_get_radio (CcChargeThresholdRow *self)
+{
+  return self->radio;
+}
+
+ChargeProfile*
+cc_charge_threshold_row_get_profile (CcChargeThresholdRow *self)
+{
+  return self->profile;
 }

--- a/panels/power/cc-charge-threshold-row.c
+++ b/panels/power/cc-charge-threshold-row.c
@@ -1,0 +1,105 @@
+#include "cc-charge-threshold-row.h"
+
+struct _CcChargeThresholdRow {
+  GtkListBoxRow parent_instance;
+  GtkRadioButton *radio;
+  char *title;
+  char *description;
+};
+
+G_DEFINE_TYPE (CcChargeThresholdRow, cc_charge_threshold_row, GTK_TYPE_LIST_BOX_ROW)
+
+enum
+{
+  PROP_0,
+  PROP_TITLE,
+  PROP_DESCRIPTION,
+  PROP_LAST
+};
+
+static void
+finalize (GObject *object)
+{
+  CcChargeThresholdRow *self = CC_CHARGE_THRESHOLD_ROW (object);
+  g_free (self->title);
+  g_free (self->description);
+}
+
+static void
+set_property (GObject      *object,
+              guint         prop_id,
+              const GValue *value,
+              GParamSpec   *pspec)
+{
+  CcChargeThresholdRow *self = CC_CHARGE_THRESHOLD_ROW (object);
+
+  switch (prop_id) {
+  case PROP_TITLE:
+    self->title = g_value_dup_string (value);
+    break;
+  case PROP_DESCRIPTION:
+    self->description = g_value_dup_string (value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+get_property (GObject    *object,
+              guint       prop_id,
+              GValue     *value,
+              GParamSpec *pspec)
+{
+  CcChargeThresholdRow *self = CC_CHARGE_THRESHOLD_ROW (object);
+
+  switch (prop_id) {
+  case PROP_TITLE:
+    g_value_set_string (value, self->title);
+    break;
+  case PROP_DESCRIPTION:
+    g_value_set_string (value, self->description);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+cc_charge_threshold_row_class_init (CcChargeThresholdRowClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  object_class->set_property = set_property;
+  object_class->get_property = get_property;
+  object_class->finalize = finalize;
+
+  g_object_class_install_property (object_class,
+                                   PROP_TITLE,
+                                   g_param_spec_string ("title",
+                                                        "title",
+                                                        "title",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+
+  g_object_class_install_property (object_class,
+                                   PROP_DESCRIPTION,
+                                   g_param_spec_string ("description",
+                                                        "description",
+                                                        "description",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/control-center/power/cc-charge-threshold-row.ui");
+
+  gtk_widget_class_bind_template_child_internal (widget_class, CcChargeThresholdRow, radio);
+}
+
+static void
+cc_charge_threshold_row_init (CcChargeThresholdRow *self)
+{
+  gtk_widget_init_template (GTK_WIDGET (self));
+}

--- a/panels/power/cc-charge-threshold-row.h
+++ b/panels/power/cc-charge-threshold-row.h
@@ -24,7 +24,23 @@
 
 G_BEGIN_DECLS
 
+typedef struct {
+  gchar *id;
+  gchar *title;
+  gchar *description;
+  guchar start;
+  guchar end;
+} ChargeProfile;
+
 #define CC_TYPE_CHARGE_THRESHOLD_ROW (cc_charge_threshold_row_get_type())
 G_DECLARE_FINAL_TYPE (CcChargeThresholdRow, cc_charge_threshold_row, CC, CHARGE_THRESHOLD_ROW, GtkListBoxRow)
+CcChargeThresholdRow* cc_charge_threshold_row_new (ChargeProfile *profile);
+GtkRadioButton* cc_charge_threshold_row_get_radio (CcChargeThresholdRow *self);
+ChargeProfile* cc_charge_threshold_row_get_profile (CcChargeThresholdRow *self);
+
+ChargeProfile *charge_profiles_get (ChargeProfile **profiles, guchar start, guchar end);
+ChargeProfile **charge_profiles_from_variant (GVariant *variant);
+ChargeProfile **charge_profiles_from_variant (GVariant *variant);
+void charge_profiles_free (ChargeProfile **profiles);
 
 G_END_DECLS

--- a/panels/power/cc-charge-threshold-row.h
+++ b/panels/power/cc-charge-threshold-row.h
@@ -1,0 +1,30 @@
+/* cc-brightness-scale.h
+ *
+ * Copyright (C) 2020 System76, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+#define CC_TYPE_CHARGE_THRESHOLD_ROW (cc_charge_threshold_row_get_type())
+G_DECLARE_FINAL_TYPE (CcChargeThresholdRow, cc_charge_threshold_row, CC, CHARGE_THRESHOLD_ROW, GtkListBoxRow)
+
+G_END_DECLS

--- a/panels/power/cc-charge-threshold-row.ui
+++ b/panels/power/cc-charge-threshold-row.ui
@@ -20,22 +20,20 @@
             <property name="visible">True</property>
             <property name="orientation">vertical</property>
             <child>
-              <object class="GtkLabel">
+              <object class="GtkLabel" id="title_label">
                 <property name="visible">True</property>
                 <property name="halign">start</property>
                 <property name="xalign">0</property>
-                <property name="label" bind-source="CcChargeThresholdRow" bind-property="title" />
               </object>
             </child>
             <child>
-              <object class="GtkLabel">
+              <object class="GtkLabel" id="description_label">
                 <property name="visible">True</property>
                 <property name="halign">start</property>
                 <property name="xalign">0</property>
                 <property name="wrap">True</property>
                 <property name="width-chars">70</property>
                 <property name="max-width-chars">70</property>
-                <property name="label" bind-source="CcChargeThresholdRow" bind-property="description" />
                 <style>
                     <class name="dim-label" />
                 </style>

--- a/panels/power/cc-charge-threshold-row.ui
+++ b/panels/power/cc-charge-threshold-row.ui
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <!-- interface-requires gtk+ 3.0 -->
+  <template class="CcChargeThresholdRow" parent="GtkListBoxRow">
+    <property name="visible">True</property>
+    <property name="activatable">True</property>
+    <property name="selectable">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="spacing">12</property>
+        <property name="margin">12</property>
+        <child>
+          <object class="GtkRadioButton" id="radio">
+            <property name="visible">True</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="label" bind-source="CcChargeThresholdRow" bind-property="title" />
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="wrap">True</property>
+                <property name="width-chars">70</property>
+                <property name="max-width-chars">70</property>
+                <property name="label" bind-source="CcChargeThresholdRow" bind-property="description" />
+                <style>
+                    <class name="dim-label" />
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -383,18 +383,6 @@ kind_to_description (UpDeviceKind kind)
   g_assert_not_reached ();
 }
 
-static UpDeviceLevel
-get_battery_level (UpDevice *device)
-{
-  UpDeviceLevel battery_level;
-
-  if (!g_object_class_find_property (G_OBJECT_CLASS (G_OBJECT_GET_CLASS (device)), "battery-level"))
-    return UP_DEVICE_LEVEL_NONE;
-
-  g_object_get (device, "battery-level", &battery_level, NULL);
-  return battery_level;
-}
-
 static void
 add_device (CcPowerPanel *panel, UpDevice *device)
 {
@@ -419,8 +407,8 @@ add_device (CcPowerPanel *panel, UpDevice *device)
                 "state", &state,
                 "model", &name,
                 "is-present", &is_present,
+                "battery-level", &battery_level,
                 NULL);
-  battery_level = get_battery_level (device);
 
   if (!is_present)
     return;

--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -108,7 +108,6 @@ struct _CcPowerPanel
   GtkWidget*     threshold_row;
   GtkWidget*     threshold_label;
   ChargeProfile **charge_profiles;
-  ChargeProfile *charge_profile;
   guint          threshold_start;
   guint          threshold_end;
 
@@ -1851,7 +1850,6 @@ charge_profiles_ready(GObject *source_object,
   if (self->charge_profiles != NULL)
     charge_profiles_free (self->charge_profiles);
   self->charge_profiles = charge_profiles;
-  self->charge_profile = profile;
 
   gtk_widget_show_all (self->threshold_row);
 
@@ -1907,7 +1905,7 @@ static void
 battery_row_activated (CcPowerPanel *self)
 {
   GtkWindow *toplevel;
-  CcChargeThresholdDialog *dialog = cc_charge_threshold_dialog_new (self->power_proxy, self->charge_profiles, self->charge_profile);
+  CcChargeThresholdDialog *dialog = cc_charge_threshold_dialog_new (self->power_proxy, self->charge_profiles, self->threshold_start, self->threshold_end);
   toplevel = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (self)));
   gtk_window_set_transient_for (GTK_WINDOW (dialog), toplevel);
   g_signal_connect_object (G_OBJECT (dialog), "destroy", G_CALLBACK (load_charge_thresholds), self, G_CONNECT_SWAPPED);

--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -343,128 +343,16 @@ add_battery (CcPowerPanel *panel, UpDevice *device, gboolean primary)
   gtk_widget_set_visible (panel->battery_section, TRUE);
 }
 
-static const char *
-kind_to_description (UpDeviceKind kind)
-{
-  switch (kind)
-    {
-      case UP_DEVICE_KIND_MOUSE:
-        /* TRANSLATORS: secondary battery */
-        return N_("Wireless mouse");
-      case UP_DEVICE_KIND_KEYBOARD:
-        /* TRANSLATORS: secondary battery */
-        return N_("Wireless keyboard");
-      case UP_DEVICE_KIND_UPS:
-        /* TRANSLATORS: secondary battery */
-        return N_("Uninterruptible power supply");
-      case UP_DEVICE_KIND_PDA:
-        /* TRANSLATORS: secondary battery */
-        return N_("Personal digital assistant");
-      case UP_DEVICE_KIND_PHONE:
-        /* TRANSLATORS: secondary battery */
-        return N_("Cellphone");
-      case UP_DEVICE_KIND_MEDIA_PLAYER:
-        /* TRANSLATORS: secondary battery */
-        return N_("Media player");
-      case UP_DEVICE_KIND_TABLET:
-        /* TRANSLATORS: secondary battery */
-        return N_("Tablet");
-      case UP_DEVICE_KIND_COMPUTER:
-        /* TRANSLATORS: secondary battery */
-        return N_("Computer");
-      case UP_DEVICE_KIND_GAMING_INPUT:
-        /* TRANSLATORS: secondary battery */
-        return N_("Gaming input device");
-      default:
-        /* TRANSLATORS: secondary battery, misc */
-        return N_("Battery");
-    }
-
-  g_assert_not_reached ();
-}
-
 static void
 add_device (CcPowerPanel *panel, UpDevice *device)
 {
-  UpDeviceKind kind;
-  UpDeviceState state;
-  GtkWidget *row;
-  GtkWidget *hbox;
-  GtkWidget *box2;
-  GtkWidget *widget;
-  GtkWidget *title;
-  g_autoptr(GString) description = NULL;
-  gdouble percentage;
-  g_autofree gchar *name = NULL;
-  gboolean is_present;
-  UpDeviceLevel battery_level;
+  CcBatteryRow *row = cc_battery_row_new (device, FALSE);
+  cc_battery_row_set_level_sizegroup (row, panel->level_sizegroup);
+  cc_battery_row_set_row_sizegroup (row, panel->row_sizegroup);
+  cc_battery_row_set_charge_sizegroup (row, panel->charge_sizegroup);
+  cc_battery_row_set_battery_sizegroup (row, panel->battery_sizegroup);
 
-  g_object_get (device,
-                "kind", &kind,
-                "percentage", &percentage,
-                "state", &state,
-                "model", &name,
-                "is-present", &is_present,
-                "battery-level", &battery_level,
-                NULL);
-
-  if (!is_present)
-    return;
-
-  if (name == NULL || *name == '\0')
-    description = g_string_new (_(kind_to_description (kind)));
-  else
-    description = g_string_new (name);
-
-  /* create the new widget */
-  row = no_prelight_row_new ();
-  gtk_widget_show (row);
-  hbox = row_box_new ();
-  gtk_container_add (GTK_CONTAINER (row), hbox);
-  title = row_title_new (description->str, NULL, NULL);
-  gtk_box_pack_start (GTK_BOX (hbox), title, FALSE, TRUE, 0);
-  gtk_size_group_add_widget (panel->battery_sizegroup, title);
-
-  box2 = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
-  gtk_widget_show (box2);
-
-  if (battery_level == UP_DEVICE_LEVEL_NONE)
-    {
-      g_autofree gchar *s = NULL;
-
-      s = g_strdup_printf ("%d%%", (int)(percentage + 0.5));
-      widget = gtk_label_new (s);
-    }
-  else
-    {
-      widget = gtk_label_new ("");
-    }
-
-  gtk_widget_show (widget);
-  gtk_widget_set_halign (widget, GTK_ALIGN_END);
-  gtk_label_set_ellipsize (GTK_LABEL (widget), PANGO_ELLIPSIZE_END);
-  gtk_label_set_xalign (GTK_LABEL (widget), 0.0);
-  gtk_style_context_add_class (gtk_widget_get_style_context (widget), GTK_STYLE_CLASS_DIM_LABEL);
-  gtk_box_pack_start (GTK_BOX (box2), widget, FALSE, TRUE, 0);
-  gtk_size_group_add_widget (panel->charge_sizegroup, widget);
-
-  widget = gtk_level_bar_new ();
-  gtk_widget_show (widget);
-  gtk_widget_set_halign (widget, TRUE);
-  gtk_widget_set_halign (widget, GTK_ALIGN_FILL);
-  gtk_widget_set_valign (widget, GTK_ALIGN_CENTER);
-  gtk_level_bar_set_value (GTK_LEVEL_BAR (widget), percentage / 100.0f);
-  gtk_level_bar_add_offset_value (GTK_LEVEL_BAR (widget), "warning-battery-offset", 0.03);
-  gtk_level_bar_add_offset_value (GTK_LEVEL_BAR (widget), "low-battery-offset", 0.1);
-  gtk_level_bar_add_offset_value (GTK_LEVEL_BAR (widget), "high-battery-offset", 1.0);
-  gtk_box_pack_start (GTK_BOX (box2), widget, TRUE, TRUE, 0);
-  gtk_size_group_add_widget (panel->level_sizegroup, widget);
-  gtk_box_pack_start (GTK_BOX (hbox), box2, TRUE, TRUE, 0);
-
-  gtk_container_add (GTK_CONTAINER (panel->device_list), row);
-  gtk_size_group_add_widget (panel->row_sizegroup, row);
-  g_object_set_data (G_OBJECT (row), "kind", GINT_TO_POINTER (kind));
-
+  gtk_container_add (GTK_CONTAINER (panel->device_list), GTK_WIDGET (row));
   gtk_widget_set_visible (panel->device_section, TRUE);
 }
 
@@ -1893,25 +1781,25 @@ add_general_section (CcPowerPanel *self)
 }
 
 static gint
-battery_sort_func (gconstpointer a, gconstpointer b, gpointer data)
+battery_sort_func (GtkListBoxRow *a, GtkListBoxRow *b, gpointer data)
 {
-  GObject *row_a = (GObject*)a;
-  GObject *row_b = (GObject*)b;
+  CcBatteryRow *row_a = CC_BATTERY_ROW (a);
+  CcBatteryRow *row_b = CC_BATTERY_ROW (b);
   gboolean a_primary;
   gboolean b_primary;
-  gint a_kind;
-  gint b_kind;
+  UpDeviceKind a_kind;
+  UpDeviceKind b_kind;
 
-  a_primary = GPOINTER_TO_INT (g_object_get_data (row_a, "primary"));
-  b_primary = GPOINTER_TO_INT (g_object_get_data (row_b, "primary"));
+  a_primary = cc_battery_row_get_primary(row_a);
+  b_primary = cc_battery_row_get_primary(row_b);
 
   if (a_primary)
     return -1;
   else if (b_primary)
     return 1;
 
-  a_kind = GPOINTER_TO_INT (g_object_get_data (row_a, "kind"));
-  b_kind = GPOINTER_TO_INT (g_object_get_data (row_b, "kind"));
+  a_kind = cc_battery_row_get_kind(row_a);
+  b_kind = cc_battery_row_get_kind(row_b);
 
   return a_kind - b_kind;
 }

--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -393,11 +393,9 @@ add_device (CcPowerPanel *panel, UpDevice *device)
   GtkWidget *box2;
   GtkWidget *widget;
   GtkWidget *title;
-  g_autoptr(GString) status = NULL;
   g_autoptr(GString) description = NULL;
   gdouble percentage;
   g_autofree gchar *name = NULL;
-  gboolean show_caution = FALSE;
   gboolean is_present;
   UpDeviceLevel battery_level;
 
@@ -413,53 +411,10 @@ add_device (CcPowerPanel *panel, UpDevice *device)
   if (!is_present)
     return;
 
-  if (kind == UP_DEVICE_KIND_UPS)
-    show_caution = TRUE;
-
   if (name == NULL || *name == '\0')
     description = g_string_new (_(kind_to_description (kind)));
   else
     description = g_string_new (name);
-
-  switch (state)
-    {
-      case UP_DEVICE_STATE_CHARGING:
-      case UP_DEVICE_STATE_PENDING_CHARGE:
-        /* TRANSLATORS: secondary battery */
-        status = g_string_new(C_("Battery power", "Charging"));
-        break;
-      case UP_DEVICE_STATE_DISCHARGING:
-      case UP_DEVICE_STATE_PENDING_DISCHARGE:
-        if (percentage < 10 && show_caution)
-          {
-            /* TRANSLATORS: secondary battery */
-            status = g_string_new (C_("Battery power", "Caution"));
-          }
-        else if (percentage < 30)
-          {
-            /* TRANSLATORS: secondary battery */
-            status = g_string_new (C_("Battery power", "Low"));
-          }
-        else
-          {
-            /* TRANSLATORS: secondary battery */
-            status = g_string_new (C_("Battery power", "Good"));
-          }
-        break;
-      case UP_DEVICE_STATE_FULLY_CHARGED:
-        /* TRANSLATORS: primary battery */
-        status = g_string_new (C_("Battery power", "Fully charged"));
-        break;
-      case UP_DEVICE_STATE_EMPTY:
-        /* TRANSLATORS: primary battery */
-        status = g_string_new (C_("Battery power", "Empty"));
-        break;
-      default:
-        status = g_string_new (up_device_state_to_string (state));
-        break;
-    }
-  g_string_prepend (status, "<small>");
-  g_string_append (status, "</small>");
 
   /* create the new widget */
   row = no_prelight_row_new ();

--- a/panels/power/data/com.system76.PowerDaemon.xml
+++ b/panels/power/data/com.system76.PowerDaemon.xml
@@ -6,8 +6,17 @@
     </method>
     <method name="Battery">
     </method>
+    <method name="GetChargeProfiles">
+      <arg name="profiles" type="aa{sv}" direction="out"/>
+    </method>
     <method name="GetChargeThresholds">
       <arg name="thresholds" type="(yy)" direction="out"/>
+    </method>
+    <method name="GetDefaultGraphics">
+      <arg name="vendor" type="s" direction="out"/>
+    </method>
+    <method name="GetExternalDisplaysRequireDGPU">
+      <arg name="required" type="b" direction="out"/>
     </method>
     <method name="GetGraphics">
       <arg name="vendor" type="s" direction="out"/>

--- a/panels/power/data/com.system76.PowerDaemon.xml
+++ b/panels/power/data/com.system76.PowerDaemon.xml
@@ -1,0 +1,47 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/com/system76/PowerDaemon">
+  <interface name="com.system76.PowerDaemon">
+    <method name="Balanced">
+    </method>
+    <method name="Battery">
+    </method>
+    <method name="GetChargeThresholds">
+      <arg name="thresholds" type="(yy)" direction="out"/>
+    </method>
+    <method name="GetGraphics">
+      <arg name="vendor" type="s" direction="out"/>
+    </method>
+    <method name="GetGraphicsPower">
+      <arg name="power" type="b" direction="out"/>
+    </method>
+    <method name="GetProfile">
+      <arg name="profile" type="s" direction="out"/>
+    </method>
+    <method name="GetSwitchable">
+      <arg name="switchable" type="b" direction="out"/>
+    </method>
+    <method name="Performance">
+    </method>
+    <method name="SetChargeThresholds">
+      <arg name="thresholds" type="(yy)" direction="in"/>
+    </method>
+    <method name="SetGraphics">
+      <arg name="vendor" type="s" direction="in"/>
+    </method>
+    <method name="SetGraphicsPower">
+      <arg name="power" type="b" direction="in"/>
+    </method>
+    <signal name="HotPlugDetect">
+      <arg name="port" type="t"/>
+    </signal>
+    <signal name="PowerProfileSwitch">
+      <arg name="profile" type="s"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" type="s" direction="out"/>
+    </method>
+  </interface>
+</node>

--- a/panels/power/meson.build
+++ b/panels/power/meson.build
@@ -18,6 +18,7 @@ i18n.merge_file(
 )
 
 sources = files(
+  'cc-battery-row.c',
   'cc-brightness-scale.c',
   'cc-power-panel.c'
 )
@@ -26,7 +27,10 @@ sources += gnome.mkenums_simple(
   'cc-brightness-scale-types',
   sources: ['cc-brightness-scale.h'])
 
-resource_data = files('cc-power-panel.ui')
+resource_data = files(
+  'cc-battery-row.ui',
+  'cc-power-panel.ui'
+)
 
 sources += gnome.compile_resources(
   'cc-' + cappletname + '-resources',

--- a/panels/power/meson.build
+++ b/panels/power/meson.build
@@ -20,6 +20,8 @@ i18n.merge_file(
 sources = files(
   'cc-battery-row.c',
   'cc-brightness-scale.c',
+  'cc-charge-threshold-dialog.c',
+  'cc-charge-threshold-row.c',
   'cc-power-panel.c'
 )
 
@@ -29,6 +31,8 @@ sources += gnome.mkenums_simple(
 
 resource_data = files(
   'cc-battery-row.ui',
+  'cc-charge-threshold-dialog.ui',
+  'cc-charge-threshold-row.ui',
   'cc-power-panel.ui'
 )
 
@@ -38,6 +42,16 @@ sources += gnome.compile_resources(
   c_name: 'cc_' + cappletname,
   dependencies: resource_data,
   export: true
+)
+
+power_namespace = 'com.system76.PowerDaemon'
+
+sources += gnome.gdbus_codegen(
+  'cc-system76-power-generated',
+  'data/' + power_namespace + '.xml',
+  interface_prefix: 'com.system76',
+  namespace: 'S76',
+  object_manager: true,
 )
 
 deps = common_deps + [

--- a/panels/power/power.gresource.xml
+++ b/panels/power/power.gresource.xml
@@ -2,6 +2,8 @@
 <gresources>
   <gresource prefix="/org/gnome/control-center/power">
     <file preprocess="xml-stripblanks">cc-battery-row.ui</file>
+    <file preprocess="xml-stripblanks">cc-charge-threshold-dialog.ui</file>
+    <file preprocess="xml-stripblanks">cc-charge-threshold-row.ui</file>
     <file preprocess="xml-stripblanks">cc-power-panel.ui</file>
     <file>battery-levels.css</file>
   </gresource>

--- a/panels/power/power.gresource.xml
+++ b/panels/power/power.gresource.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/org/gnome/control-center/power">
+    <file preprocess="xml-stripblanks">cc-battery-row.ui</file>
     <file preprocess="xml-stripblanks">cc-power-panel.ui</file>
     <file>battery-levels.css</file>
   </gresource>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -150,6 +150,7 @@ panels/notifications/gnome-notifications-panel.desktop.in.in
 panels/online-accounts/cc-online-accounts-panel.c
 panels/online-accounts/gnome-online-accounts-panel.desktop.in.in
 panels/online-accounts/online-accounts.ui
+panels/power/cc-battery-row.c
 panels/power/cc-power-panel.c
 panels/power/cc-power-panel.ui
 panels/power/gnome-power-panel.desktop.in.in


### PR DESCRIPTION
This follows the threshold values and descriptions from https://github.com/pop-os/gnome-control-center/issues/101#issuecomment-761218148, though the styling uses a ListBox to match other parts of Gnome Control Center (especially the Alt Chars / Compose Key dialogs).

![Screenshot from 2021-01-19 10-15-52](https://user-images.githubusercontent.com/2263150/105076441-e963bf80-5a3f-11eb-888a-37d02a72b441.png)

This dialog is opened by pressing the thresholds row here, which shows up on System76 systems with the right firmware / software:

![Screenshot from 2021-01-19 10-21-23](https://user-images.githubusercontent.com/2263150/105076623-22039900-5a40-11eb-8148-8d40f9d435e0.png)

Changing the value opens a dialog through polkit, since administrator permission should be required for changing persistent settings:

![Screenshot from 2021-01-19 10-16-15](https://user-images.githubusercontent.com/2263150/105076806-6b53e880-5a40-11eb-8d30-c24b5d8b632a.png)

Requires https://github.com/pop-os/system76-power/pull/197 and firmware with thresholds support. If someone wants to test it without such firmware, I have code locally for system76-power to fake thresholds support.

(Note: commits before the one adding thresholds are already MR'd and merged upstream. Refactoring the code made it cleaner to add this, and just helped me understand the power panel code.)

## Question

I don't know that it's been proposed in previous discussion, but do we want something like a toggle to disable thresholds? Users may not be happy with the fact that this includes no option to charge starting above 88%.

Also, currently the default in the firmware is 0:100, which disables charge thresholds. This is not any of these profiles, so it displays like this:

![Screenshot from 2021-01-19 09-40-06](https://user-images.githubusercontent.com/2263150/105077120-e1f0e600-5a40-11eb-9ce3-a1f3220ecaf8.png)

Whatever we end up deciding, the default option should be something exposed through the UI, whether it's disabled thresholds or one of these profiles.

(In any case, power users will be free to set any values they want through the `system76-power` CLI.)

## State of firmware

Most open firmware systems do not have released firmware with charge thresholds, and the EC doesn't currently persist thresholds (https://github.com/system76/ec/issues/128).
