### PR TITLE
pop-upgrade: Update panel name & notification destination to match Groovy/Focal

### DIFF
--- a/debian/patches/pop-upgrade.patch
+++ b/debian/patches/pop-upgrade.patch
@@ -1,8 +1,6 @@
-Index: gnome-control-center/shell/cc-application.c
-===================================================================
---- gnome-control-center.orig/shell/cc-application.c
-+++ gnome-control-center/shell/cc-application.c
-@@ -199,6 +199,10 @@ cc_application_quit (GSimpleAction *simp
+--- a/shell/cc-application.c
++++ b/shell/cc-application.c
+@@ -200,6 +200,10 @@
  {
    CcApplication *self = CC_APPLICATION (user_data);
  
@@ -13,11 +11,9 @@ Index: gnome-control-center/shell/cc-application.c
    gtk_widget_destroy (GTK_WIDGET (self->window));
  }
  
-Index: gnome-control-center/shell/cc-window.c
-===================================================================
---- gnome-control-center.orig/shell/cc-window.c
-+++ gnome-control-center/shell/cc-window.c
-@@ -671,6 +671,10 @@ window_key_press_event_cb (CcWindow    *
+--- a/shell/cc-window.c
++++ b/shell/cc-window.c
+@@ -645,6 +645,10 @@
            case GDK_KEY_q:
            case GDK_KEY_W:
            case GDK_KEY_w:
@@ -28,7 +24,7 @@ Index: gnome-control-center/shell/cc-window.c
              gtk_widget_destroy (GTK_WIDGET (self));
              retval = GDK_EVENT_STOP;
              break;
-@@ -755,6 +759,14 @@ cc_shell_iface_init (CcShellInterface *i
+@@ -729,6 +733,14 @@
    iface->get_toplevel = cc_window_get_toplevel;
  }
  
@@ -43,7 +39,7 @@ Index: gnome-control-center/shell/cc-window.c
  /* GtkWidget overrides */
  static void
  cc_window_map (GtkWidget *widget)
-@@ -763,6 +775,8 @@ cc_window_map (GtkWidget *widget)
+@@ -737,6 +749,8 @@
  
    GTK_WIDGET_CLASS (cc_window_parent_class)->map (widget);
  
@@ -52,10 +48,8 @@ Index: gnome-control-center/shell/cc-window.c
    /* Show a warning for Flatpak builds */
    if (in_flatpak_sandbox () && g_settings_get_boolean (self->settings, "show-development-warning"))
      gtk_window_present (GTK_WINDOW (self->development_warning_dialog));
-Index: gnome-control-center/shell/cc-window.h
-===================================================================
---- gnome-control-center.orig/shell/cc-window.h
-+++ gnome-control-center/shell/cc-window.h
+--- a/shell/cc-window.h
++++ b/shell/cc-window.h
 @@ -24,6 +24,8 @@
  #include "cc-shell.h"
  #include "cc-shell-model.h"
@@ -65,10 +59,8 @@ Index: gnome-control-center/shell/cc-window.h
  G_BEGIN_DECLS
  
  #define CC_TYPE_WINDOW (cc_window_get_type ())
-Index: gnome-control-center/panels/upgrade/cc-upgrade-panel.c
-===================================================================
 --- /dev/null
-+++ gnome-control-center/panels/upgrade/cc-upgrade-panel.c
++++ b/panels/upgrade/cc-upgrade-panel.c
 @@ -0,0 +1,135 @@
 +
 +#include <config.h>
@@ -117,7 +109,7 @@ Index: gnome-control-center/panels/upgrade/cc-upgrade-panel.c
 +/* Triggers when the upgrade ready notification is clicked. */
 +static void pop_upgrade_callback_ready (gpointer user_data) {
 +    g_autoptr(GError) error = NULL;
-+    gchar *argv[] = { "/usr/bin/gnome-control-center", "info-overview", NULL };
++    gchar *argv[] = { "/usr/bin/gnome-control-center", "upgrade", NULL };
 +    if (!g_spawn_async (NULL, argv, NULL, 0, NULL, NULL, NULL, &error)) {
 +        g_warning ("Failed to open info overview: %s", error->message);
 +    }
@@ -205,10 +197,8 @@ Index: gnome-control-center/panels/upgrade/cc-upgrade-panel.c
 +
 +    gtk_container_add (GTK_CONTAINER (prefs), prefs->overlay);
 +}
-Index: gnome-control-center/panels/upgrade/cc-upgrade-panel.h
-===================================================================
 --- /dev/null
-+++ gnome-control-center/panels/upgrade/cc-upgrade-panel.h
++++ b/panels/upgrade/cc-upgrade-panel.h
 @@ -0,0 +1,32 @@
 +/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
 + *
@@ -242,13 +232,11 @@ Index: gnome-control-center/panels/upgrade/cc-upgrade-panel.h
 +                     CcPanel)
 +
 +G_END_DECLS
-Index: gnome-control-center/panels/upgrade/gnome-upgrade-panel.desktop.in.in
-===================================================================
 --- /dev/null
-+++ gnome-control-center/panels/upgrade/gnome-upgrade-panel.desktop.in.in
++++ b/panels/upgrade/gnome-upgrade-panel.desktop.in.in
 @@ -0,0 +1,14 @@
 +[Desktop Entry]
-+Name=OS Upgrade
++Name=OS Upgrade & Recovery
 +Comment=View system upgrade information
 +Exec=gnome-control-center upgrade
 +Icon=software-update-available-symbolic
@@ -261,10 +249,8 @@ Index: gnome-control-center/panels/upgrade/gnome-upgrade-panel.desktop.in.in
 +Keywords=OS;Upgrade;
 +# Notifications are emitted by gnome-settings-daemon
 +X-GNOME-UsesNotifications=true
-Index: gnome-control-center/panels/upgrade/meson.build
-===================================================================
 --- /dev/null
-+++ gnome-control-center/panels/upgrade/meson.build
++++ b/panels/upgrade/meson.build
 @@ -0,0 +1,39 @@
 +panels_list += cappletname
 +desktop = 'gnome-@0@-panel.desktop'.format(cappletname)
@@ -305,11 +291,9 @@ Index: gnome-control-center/panels/upgrade/meson.build
 +  dependencies: deps,
 +  c_args: cflags
 +)
-Index: gnome-control-center/panels/meson.build
-===================================================================
---- gnome-control-center.orig/panels/meson.build
-+++ gnome-control-center/panels/meson.build
-@@ -27,6 +27,7 @@ panels = [
+--- a/panels/meson.build
++++ b/panels/meson.build
+@@ -27,6 +27,7 @@
    'sound',
    'universal-access',
    'usage',
@@ -317,11 +301,9 @@ Index: gnome-control-center/panels/meson.build
    'user-accounts'
  ]
  
-Index: gnome-control-center/shell/cc-panel-list.c
-===================================================================
---- gnome-control-center.orig/shell/cc-panel-list.c
-+++ gnome-control-center/shell/cc-panel-list.c
-@@ -425,6 +425,7 @@ static const gchar * const panel_order[]
+--- a/shell/cc-panel-list.c
++++ b/shell/cc-panel-list.c
+@@ -425,6 +425,7 @@
    "reset-settings",
    "datetime",
    "info-overview",
@@ -329,16 +311,14 @@ Index: gnome-control-center/shell/cc-panel-list.c
  };
  
  static guint
-@@ -1109,4 +1110,3 @@ cc_panel_list_set_selection_mode (CcPane
+@@ -1109,4 +1110,3 @@
        gtk_list_box_select_row (GTK_LIST_BOX (listbox), GTK_LIST_BOX_ROW (data->row));
      }
  }
 -
-Index: gnome-control-center/shell/cc-panel-loader.c
-===================================================================
---- gnome-control-center.orig/shell/cc-panel-loader.c
-+++ gnome-control-center/shell/cc-panel-loader.c
-@@ -61,6 +61,7 @@ extern GType cc_sound_panel_get_type (vo
+--- a/shell/cc-panel-loader.c
++++ b/shell/cc-panel-loader.c
+@@ -61,6 +61,7 @@
  extern GType cc_bolt_panel_get_type (void);
  #endif /* BUILD_THUNDERBOLT */
  extern GType cc_ua_panel_get_type (void);
@@ -346,7 +326,7 @@ Index: gnome-control-center/shell/cc-panel-loader.c
  extern GType cc_user_panel_get_type (void);
  #ifdef BUILD_WACOM
  extern GType cc_wacom_panel_get_type (void);
-@@ -127,6 +128,7 @@ static CcPanelLoaderVtable default_panel
+@@ -127,6 +128,7 @@
  #endif
    PANEL_TYPE("universal-access", cc_ua_panel_get_type,                   NULL),
    PANEL_TYPE("usage",            cc_usage_panel_get_type,                NULL),

--- a/debian/patches/pop-upgrade.patch
+++ b/debian/patches/pop-upgrade.patch
@@ -1,6 +1,8 @@
---- a/shell/cc-application.c
-+++ b/shell/cc-application.c
-@@ -200,6 +200,10 @@
+Index: gnome-control-center/shell/cc-application.c
+===================================================================
+--- gnome-control-center.orig/shell/cc-application.c
++++ gnome-control-center/shell/cc-application.c
+@@ -200,6 +200,10 @@ cc_application_quit (GSimpleAction *simp
  {
    CcApplication *self = CC_APPLICATION (user_data);
  
@@ -11,9 +13,11 @@
    gtk_widget_destroy (GTK_WIDGET (self->window));
  }
  
---- a/shell/cc-window.c
-+++ b/shell/cc-window.c
-@@ -645,6 +645,10 @@
+Index: gnome-control-center/shell/cc-window.c
+===================================================================
+--- gnome-control-center.orig/shell/cc-window.c
++++ gnome-control-center/shell/cc-window.c
+@@ -671,6 +671,10 @@ window_key_press_event_cb (CcWindow    *
            case GDK_KEY_q:
            case GDK_KEY_W:
            case GDK_KEY_w:
@@ -24,7 +28,7 @@
              gtk_widget_destroy (GTK_WIDGET (self));
              retval = GDK_EVENT_STOP;
              break;
-@@ -729,6 +733,14 @@
+@@ -729,6 +733,14 @@ cc_shell_iface_init (CcShellInterface *i
    iface->get_toplevel = cc_window_get_toplevel;
  }
  
@@ -39,7 +43,7 @@
  /* GtkWidget overrides */
  static void
  cc_window_map (GtkWidget *widget)
-@@ -737,6 +749,8 @@
+@@ -737,6 +749,8 @@ cc_window_map (GtkWidget *widget)
  
    GTK_WIDGET_CLASS (cc_window_parent_class)->map (widget);
  
@@ -48,8 +52,10 @@
    /* Show a warning for Flatpak builds */
    if (in_flatpak_sandbox () && g_settings_get_boolean (self->settings, "show-development-warning"))
      gtk_window_present (GTK_WINDOW (self->development_warning_dialog));
---- a/shell/cc-window.h
-+++ b/shell/cc-window.h
+Index: gnome-control-center/shell/cc-window.h
+===================================================================
+--- gnome-control-center.orig/shell/cc-window.h
++++ gnome-control-center/shell/cc-window.h
 @@ -24,6 +24,8 @@
  #include "cc-shell.h"
  #include "cc-shell-model.h"
@@ -59,8 +65,10 @@
  G_BEGIN_DECLS
  
  #define CC_TYPE_WINDOW (cc_window_get_type ())
+Index: gnome-control-center/panels/upgrade/cc-upgrade-panel.c
+===================================================================
 --- /dev/null
-+++ b/panels/upgrade/cc-upgrade-panel.c
++++ gnome-control-center/panels/upgrade/cc-upgrade-panel.c
 @@ -0,0 +1,135 @@
 +
 +#include <config.h>
@@ -197,8 +205,10 @@
 +
 +    gtk_container_add (GTK_CONTAINER (prefs), prefs->overlay);
 +}
+Index: gnome-control-center/panels/upgrade/cc-upgrade-panel.h
+===================================================================
 --- /dev/null
-+++ b/panels/upgrade/cc-upgrade-panel.h
++++ gnome-control-center/panels/upgrade/cc-upgrade-panel.h
 @@ -0,0 +1,32 @@
 +/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
 + *
@@ -232,8 +242,10 @@
 +                     CcPanel)
 +
 +G_END_DECLS
+Index: gnome-control-center/panels/upgrade/gnome-upgrade-panel.desktop.in.in
+===================================================================
 --- /dev/null
-+++ b/panels/upgrade/gnome-upgrade-panel.desktop.in.in
++++ gnome-control-center/panels/upgrade/gnome-upgrade-panel.desktop.in.in
 @@ -0,0 +1,14 @@
 +[Desktop Entry]
 +Name=OS Upgrade & Recovery
@@ -249,8 +261,10 @@
 +Keywords=OS;Upgrade;
 +# Notifications are emitted by gnome-settings-daemon
 +X-GNOME-UsesNotifications=true
+Index: gnome-control-center/panels/upgrade/meson.build
+===================================================================
 --- /dev/null
-+++ b/panels/upgrade/meson.build
++++ gnome-control-center/panels/upgrade/meson.build
 @@ -0,0 +1,39 @@
 +panels_list += cappletname
 +desktop = 'gnome-@0@-panel.desktop'.format(cappletname)
@@ -291,9 +305,11 @@
 +  dependencies: deps,
 +  c_args: cflags
 +)
---- a/panels/meson.build
-+++ b/panels/meson.build
-@@ -27,6 +27,7 @@
+Index: gnome-control-center/panels/meson.build
+===================================================================
+--- gnome-control-center.orig/panels/meson.build
++++ gnome-control-center/panels/meson.build
+@@ -27,6 +27,7 @@ panels = [
    'sound',
    'universal-access',
    'usage',
@@ -301,9 +317,11 @@
    'user-accounts'
  ]
  
---- a/shell/cc-panel-list.c
-+++ b/shell/cc-panel-list.c
-@@ -425,6 +425,7 @@
+Index: gnome-control-center/shell/cc-panel-list.c
+===================================================================
+--- gnome-control-center.orig/shell/cc-panel-list.c
++++ gnome-control-center/shell/cc-panel-list.c
+@@ -425,6 +425,7 @@ static const gchar * const panel_order[]
    "reset-settings",
    "datetime",
    "info-overview",
@@ -311,14 +329,16 @@
  };
  
  static guint
-@@ -1109,4 +1110,3 @@
+@@ -1109,4 +1110,3 @@ cc_panel_list_set_selection_mode (CcPane
        gtk_list_box_select_row (GTK_LIST_BOX (listbox), GTK_LIST_BOX_ROW (data->row));
      }
  }
 -
---- a/shell/cc-panel-loader.c
-+++ b/shell/cc-panel-loader.c
-@@ -61,6 +61,7 @@
+Index: gnome-control-center/shell/cc-panel-loader.c
+===================================================================
+--- gnome-control-center.orig/shell/cc-panel-loader.c
++++ gnome-control-center/shell/cc-panel-loader.c
+@@ -61,6 +61,7 @@ extern GType cc_sound_panel_get_type (vo
  extern GType cc_bolt_panel_get_type (void);
  #endif /* BUILD_THUNDERBOLT */
  extern GType cc_ua_panel_get_type (void);
@@ -326,7 +346,7 @@
  extern GType cc_user_panel_get_type (void);
  #ifdef BUILD_WACOM
  extern GType cc_wacom_panel_get_type (void);
-@@ -127,6 +128,7 @@
+@@ -127,6 +128,7 @@ static CcPanelLoaderVtable default_panel
  #endif
    PANEL_TYPE("universal-access", cc_ua_panel_get_type,                   NULL),
    PANEL_TYPE("usage",            cc_usage_panel_get_type,                NULL),


### PR DESCRIPTION
Applies https://github.com/pop-os/gnome-control-center/pull/154 and https://github.com/pop-os/gnome-control-center/pull/176 for Hirsute.