### PR TITLE
Add patch to remove search panel

### DIFF
--- a/debian/patches/pop-no-search.patch
+++ b/debian/patches/pop-no-search.patch
@@ -1,0 +1,24 @@
+diff --git a/panels/meson.build b/panels/meson.build
+index 2f4fdc5e3..3d3a1bcae 100644
+--- a/panels/meson.build
++++ b/panels/meson.build
+@@ -21,7 +21,6 @@ panels = [
+   'printers',
+   'region',
+   'removable-media',
+-  'search',
+   'sharing',
+   'sound',
+   'universal-access',
+diff --git a/shell/cc-panel-loader.c b/shell/cc-panel-loader.c
+index f20384394..31e2348fd 100644
+--- a/shell/cc-panel-loader.c
++++ b/shell/cc-panel-loader.c
+@@ -117,7 +117,6 @@ static CcPanelLoaderVtable default_panels[] =
+   PANEL_TYPE("printers",         cc_printers_panel_get_type,             NULL),
+   PANEL_TYPE("region",           cc_region_panel_get_type,               NULL),
+   PANEL_TYPE("removable-media",  cc_removable_media_panel_get_type,      NULL),
+-  PANEL_TYPE("search",           cc_search_panel_get_type,               NULL),
+   PANEL_TYPE("sharing",          cc_sharing_panel_get_type,              NULL),
+   PANEL_TYPE("sound",            cc_sound_panel_get_type,                NULL),
+ #ifdef BUILD_THUNDERBOLT

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -55,3 +55,4 @@ Revert-user-accounts-Use-custom-setting-to-override-.patch
 cc-search-locations-dialog.patch
 0001-shell-Fix-bug-when-multiple-panels-use-custom-sideba.patch
 pop-desktop-widget.patch
+pop-no-search.patch


### PR DESCRIPTION
I tried to just hide the panel, but `CC_PANEL_HIDDEN` seems to prevent it from opening even from the command line.

https://github.com/pop-os/gnome-control-center/issues/165