### PR TITLE
fix: Remove `.desktop` files for privacy camera/microphone

### DIFF
--- a/debian/patches/pop/camera-microphone-desktop.patch
+++ b/debian/patches/pop/camera-microphone-desktop.patch
@@ -1,0 +1,18 @@
+--- a/panels/meson.build
++++ b/panels/meson.build
+@@ -3,7 +3,6 @@
+ panels = [
+   'applications',
+   'background',
+-  'camera',
+   'color',
+   'connectivity',
+   'datetime',
+@@ -14,7 +13,6 @@
+   'keyboard',
+   'location',
+   'lock',
+-  'microphone',
+   'mouse',
+   'notifications',
+   'online-accounts',

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -54,3 +54,4 @@ pop/pop-desktop-widget.patch
 pop/pop-no-search.patch
 pop/0001-keyboard-Pop-_OS-changes-with-support-for-multiple-b.patch
 pop/pop-support.patch
+pop/camera-microphone-desktop.patch


### PR DESCRIPTION
These panels are disabled in `ubuntu/Disable-non-working-camera-microphones-panels.patch`, but their `.desktop` files still were installed.