### PR TITLE
Set analytics and support icons

### DIFF
--- a/debian/patches/pop/pop-analytics.patch
+++ b/debian/patches/pop/pop-analytics.patch
@@ -97,7 +97,7 @@ Index: gnome-control-center/panels/analytics/gnome-analytics-panel.desktop.in.in
 +Type=Application
 +NoDisplay=true
 +StartupNotify=true
-+Categories=GNOME;GTK;Settings;X-GNOME-Settings-Panel;HardwareSettings;X-GNOME-DetailsSettings;
++Categories=GNOME;GTK;Settings;X-GNOME-Settings-Panel;HardwareSettings;X-GNOME-PrivacySettings;
 +Keywords=hp;analytics;
 +# Notifications are emitted by gnome-settings-daemon
 +X-GNOME-UsesNotifications=true
@@ -160,14 +160,14 @@ Index: gnome-control-center/shell/cc-panel-list.c
 ===================================================================
 --- gnome-control-center.orig/shell/cc-panel-list.c
 +++ gnome-control-center/shell/cc-panel-list.c
-@@ -444,6 +444,7 @@ static const gchar * const panel_order[]
-   "info-overview",
-   "upgrade",
-   "support",
+@@ -421,6 +421,7 @@ static const gchar * const panel_order[]
+   "thunderbolt",
+   "usage",
+   "lock",
 +  "analytics",
- };
  
- static guint
+   /* Devices page */
+   "sound",
 Index: gnome-control-center/shell/cc-panel-loader.c
 ===================================================================
 --- gnome-control-center.orig/shell/cc-panel-loader.c

--- a/debian/patches/pop/pop-analytics.patch
+++ b/debian/patches/pop/pop-analytics.patch
@@ -1,5 +1,7 @@
+Index: gnome-control-center/panels/analytics/cc-analytics-panel.c
+===================================================================
 --- /dev/null
-+++ b/panels/analytics/cc-analytics-panel.c
++++ gnome-control-center/panels/analytics/cc-analytics-panel.c
 @@ -0,0 +1,58 @@
 +// Copyright 2022 System76 <info@system76.com>
 +// SPDX-License-Identifier: GPL-2.0
@@ -59,8 +61,10 @@
 +                                           CC_PANEL_HIDDEN);
 +    }
 +}
+Index: gnome-control-center/panels/analytics/cc-analytics-panel.h
+===================================================================
 --- /dev/null
-+++ b/panels/analytics/cc-analytics-panel.h
++++ gnome-control-center/panels/analytics/cc-analytics-panel.h
 @@ -0,0 +1,17 @@
 +// Copyright 2022 System76 <info@system76.com>
 +// SPDX-License-Identifier: GPL-2.0
@@ -79,14 +83,16 @@
 +void cc_analytics_panel_static_init_func (void);
 +
 +G_END_DECLS
+Index: gnome-control-center/panels/analytics/gnome-analytics-panel.desktop.in.in
+===================================================================
 --- /dev/null
-+++ b/panels/analytics/gnome-analytics-panel.desktop.in.in
++++ gnome-control-center/panels/analytics/gnome-analytics-panel.desktop.in.in
 @@ -0,0 +1,13 @@
 +[Desktop Entry]
 +Name=Analytics
 +Comment=Analytics info
 +Exec=gnome-control-center analytics
-+Icon=help-about-symbolic
++Icon=pop-analytics
 +Terminal=false
 +Type=Application
 +NoDisplay=true
@@ -95,8 +101,10 @@
 +Keywords=hp;analytics;
 +# Notifications are emitted by gnome-settings-daemon
 +X-GNOME-UsesNotifications=true
+Index: gnome-control-center/panels/analytics/meson.build
+===================================================================
 --- /dev/null
-+++ b/panels/analytics/meson.build
++++ gnome-control-center/panels/analytics/meson.build
 @@ -0,0 +1,38 @@
 +panels_list += cappletname
 +desktop = 'gnome-@0@-panel.desktop'.format(cappletname)
@@ -136,8 +144,10 @@
 +  dependencies: deps,
 +  c_args: cflags
 +)
---- a/panels/meson.build
-+++ b/panels/meson.build
+Index: gnome-control-center/panels/meson.build
+===================================================================
+--- gnome-control-center.orig/panels/meson.build
++++ gnome-control-center/panels/meson.build
 @@ -1,6 +1,7 @@
  subdir('common')
  
@@ -146,9 +156,11 @@
    'applications',
    'background',
    'desktop-appearance',
---- a/shell/cc-panel-list.c
-+++ b/shell/cc-panel-list.c
-@@ -444,6 +444,7 @@
+Index: gnome-control-center/shell/cc-panel-list.c
+===================================================================
+--- gnome-control-center.orig/shell/cc-panel-list.c
++++ gnome-control-center/shell/cc-panel-list.c
+@@ -444,6 +444,7 @@ static const gchar * const panel_order[]
    "info-overview",
    "upgrade",
    "support",
@@ -156,9 +168,11 @@
  };
  
  static guint
---- a/shell/cc-panel-loader.c
-+++ b/shell/cc-panel-loader.c
-@@ -59,6 +59,7 @@
+Index: gnome-control-center/shell/cc-panel-loader.c
+===================================================================
+--- gnome-control-center.orig/shell/cc-panel-loader.c
++++ gnome-control-center/shell/cc-panel-loader.c
+@@ -59,6 +59,7 @@ extern GType cc_search_panel_get_type (v
  extern GType cc_sharing_panel_get_type (void);
  extern GType cc_sound_panel_get_type (void);
  extern GType cc_support_panel_get_type(void);
@@ -166,7 +180,7 @@
  #ifdef BUILD_THUNDERBOLT
  extern GType cc_bolt_panel_get_type (void);
  #endif /* BUILD_THUNDERBOLT */
-@@ -93,6 +94,7 @@
+@@ -93,6 +94,7 @@ extern void cc_wacom_panel_static_init_f
  extern void cc_wwan_panel_static_init_func (void);
  #endif /* BUILD_WWAN */
  extern void cc_ubuntu_panel_static_init_func (void);
@@ -174,7 +188,7 @@
  
  #define PANEL_TYPE(name, get_type, init_func) { name, get_type, init_func }
  
-@@ -135,6 +137,7 @@
+@@ -135,6 +137,7 @@ static CcPanelLoaderVtable default_panel
    PANEL_TYPE("sharing",          cc_sharing_panel_get_type,              NULL),
    PANEL_TYPE("sound",            cc_sound_panel_get_type,                NULL),
    PANEL_TYPE("support",          cc_support_panel_get_type,              NULL),

--- a/debian/patches/pop/pop-support.patch
+++ b/debian/patches/pop/pop-support.patch
@@ -2,14 +2,14 @@ Index: gnome-control-center/shell/cc-panel-list.c
 ===================================================================
 --- gnome-control-center.orig/shell/cc-panel-list.c
 +++ gnome-control-center/shell/cc-panel-list.c
-@@ -423,6 +423,7 @@ static const gchar * const panel_order[]
+@@ -422,6 +422,7 @@ static const gchar * const panel_order[]
+   "reset-settings",
    "datetime",
-   "info-overview",
    "upgrade",
 +  "support",
+   "info-overview",
  };
  
- static guint
 Index: gnome-control-center/shell/cc-panel-loader.c
 ===================================================================
 --- gnome-control-center.orig/shell/cc-panel-loader.c

--- a/debian/patches/pop/pop-support.patch
+++ b/debian/patches/pop/pop-support.patch
@@ -1,6 +1,8 @@
---- a/shell/cc-panel-list.c
-+++ b/shell/cc-panel-list.c
-@@ -423,6 +423,7 @@
+Index: gnome-control-center/shell/cc-panel-list.c
+===================================================================
+--- gnome-control-center.orig/shell/cc-panel-list.c
++++ gnome-control-center/shell/cc-panel-list.c
+@@ -423,6 +423,7 @@ static const gchar * const panel_order[]
    "datetime",
    "info-overview",
    "upgrade",
@@ -8,9 +10,11 @@
  };
  
  static guint
---- a/shell/cc-panel-loader.c
-+++ b/shell/cc-panel-loader.c
-@@ -59,6 +59,7 @@
+Index: gnome-control-center/shell/cc-panel-loader.c
+===================================================================
+--- gnome-control-center.orig/shell/cc-panel-loader.c
++++ gnome-control-center/shell/cc-panel-loader.c
+@@ -59,6 +59,7 @@ extern GType cc_removable_media_panel_ge
  extern GType cc_search_panel_get_type (void);
  extern GType cc_sharing_panel_get_type (void);
  extern GType cc_sound_panel_get_type (void);
@@ -18,7 +22,7 @@
  #ifdef BUILD_THUNDERBOLT
  extern GType cc_bolt_panel_get_type (void);
  #endif /* BUILD_THUNDERBOLT */
-@@ -131,6 +132,7 @@
+@@ -131,6 +132,7 @@ static CcPanelLoaderVtable default_panel
    PANEL_TYPE("removable-media",  cc_removable_media_panel_get_type,      NULL),
    PANEL_TYPE("sharing",          cc_sharing_panel_get_type,              NULL),
    PANEL_TYPE("sound",            cc_sound_panel_get_type,                NULL),
@@ -26,9 +30,11 @@
    PANEL_TYPE("ubuntu",           cc_ubuntu_panel_get_type,               cc_ubuntu_panel_static_init_func),
  #ifdef BUILD_THUNDERBOLT
    PANEL_TYPE("thunderbolt",      cc_bolt_panel_get_type,                 NULL),
---- a/panels/meson.build
-+++ b/panels/meson.build
-@@ -25,6 +25,7 @@
+Index: gnome-control-center/panels/meson.build
+===================================================================
+--- gnome-control-center.orig/panels/meson.build
++++ gnome-control-center/panels/meson.build
+@@ -25,6 +25,7 @@ panels = [
    'removable-media',
    'sharing',
    'sound',
@@ -36,8 +42,10 @@
    'ubuntu',
    'universal-access',
    'usage',
+Index: gnome-control-center/panels/support/cc-support-panel.c
+===================================================================
 --- /dev/null
-+++ b/panels/support/cc-support-panel.c
++++ gnome-control-center/panels/support/cc-support-panel.c
 @@ -0,0 +1,43 @@
 +
 +#include <config.h>
@@ -82,8 +90,10 @@
 +    // Attach after idling so we'll have access to the window as a toplevel.
 +    g_idle_add ((GSourceFunc) attach_panel, GTK_CONTAINER (self));
 +}
+Index: gnome-control-center/panels/support/cc-support-panel.h
+===================================================================
 --- /dev/null
-+++ b/panels/support/cc-support-panel.h
++++ gnome-control-center/panels/support/cc-support-panel.h
 @@ -0,0 +1,32 @@
 +/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
 + *
@@ -117,8 +127,10 @@
 +                     CcPanel)
 +
 +G_END_DECLS
+Index: gnome-control-center/panels/support/meson.build
+===================================================================
 --- /dev/null
-+++ b/panels/support/meson.build
++++ gnome-control-center/panels/support/meson.build
 @@ -0,0 +1,38 @@
 +panels_list += cappletname
 +desktop = 'gnome-@0@-panel.desktop'.format(cappletname)
@@ -158,14 +170,16 @@
 +  dependencies: deps,
 +  c_args: cflags
 +)
+Index: gnome-control-center/panels/support/gnome-support-panel.desktop.in.in
+===================================================================
 --- /dev/null
-+++ b/panels/support/gnome-support-panel.desktop.in.in
++++ gnome-control-center/panels/support/gnome-support-panel.desktop.in.in
 @@ -0,0 +1,14 @@
 +[Desktop Entry]
 +Name=Support
 +Comment=View available support information
 +Exec=gnome-control-center support
-+Icon=help-about-symbolic
++Icon=pop-support
 +Terminal=false
 +Type=Application
 +NoDisplay=true

--- a/debian/patches/pop/pop-upgrade.patch
+++ b/debian/patches/pop/pop-upgrade.patch
@@ -1,6 +1,8 @@
---- a/shell/cc-application.c
-+++ b/shell/cc-application.c
-@@ -200,6 +200,10 @@
+Index: gnome-control-center/shell/cc-application.c
+===================================================================
+--- gnome-control-center.orig/shell/cc-application.c
++++ gnome-control-center/shell/cc-application.c
+@@ -200,6 +200,10 @@ cc_application_quit (GSimpleAction *simp
  {
    CcApplication *self = CC_APPLICATION (user_data);
  
@@ -11,9 +13,11 @@
    gtk_widget_destroy (GTK_WIDGET (self->window));
  }
  
---- a/shell/cc-window.c
-+++ b/shell/cc-window.c
-@@ -650,6 +650,10 @@
+Index: gnome-control-center/shell/cc-window.c
+===================================================================
+--- gnome-control-center.orig/shell/cc-window.c
++++ gnome-control-center/shell/cc-window.c
+@@ -650,6 +650,10 @@ window_key_press_event_cb (CcWindow    *
            case GDK_KEY_q:
            case GDK_KEY_W:
            case GDK_KEY_w:
@@ -24,7 +28,7 @@
              gtk_widget_destroy (GTK_WIDGET (self));
              retval = GDK_EVENT_STOP;
              break;
-@@ -734,6 +738,14 @@
+@@ -734,6 +738,14 @@ cc_shell_iface_init (CcShellInterface *i
    iface->get_toplevel = cc_window_get_toplevel;
  }
  
@@ -39,7 +43,7 @@
  /* GtkWidget overrides */
  static void
  cc_window_map (GtkWidget *widget)
-@@ -742,6 +754,8 @@
+@@ -742,6 +754,8 @@ cc_window_map (GtkWidget *widget)
  
    GTK_WIDGET_CLASS (cc_window_parent_class)->map (widget);
  
@@ -48,8 +52,10 @@
    /* Show a warning for Flatpak builds */
    if (in_flatpak_sandbox () && g_settings_get_boolean (self->settings, "show-development-warning"))
      gtk_window_present (GTK_WINDOW (self->development_warning_dialog));
---- a/shell/cc-window.h
-+++ b/shell/cc-window.h
+Index: gnome-control-center/shell/cc-window.h
+===================================================================
+--- gnome-control-center.orig/shell/cc-window.h
++++ gnome-control-center/shell/cc-window.h
 @@ -24,6 +24,8 @@
  #include "cc-shell.h"
  #include "cc-shell-model.h"
@@ -59,8 +65,10 @@
  G_BEGIN_DECLS
  
  #define CC_TYPE_WINDOW (cc_window_get_type ())
+Index: gnome-control-center/panels/upgrade/cc-upgrade-panel.c
+===================================================================
 --- /dev/null
-+++ b/panels/upgrade/cc-upgrade-panel.c
++++ gnome-control-center/panels/upgrade/cc-upgrade-panel.c
 @@ -0,0 +1,135 @@
 +
 +#include <config.h>
@@ -197,8 +205,10 @@
 +
 +    gtk_container_add (GTK_CONTAINER (prefs), prefs->overlay);
 +}
+Index: gnome-control-center/panels/upgrade/cc-upgrade-panel.h
+===================================================================
 --- /dev/null
-+++ b/panels/upgrade/cc-upgrade-panel.h
++++ gnome-control-center/panels/upgrade/cc-upgrade-panel.h
 @@ -0,0 +1,32 @@
 +/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
 + *
@@ -232,8 +242,10 @@
 +                     CcPanel)
 +
 +G_END_DECLS
+Index: gnome-control-center/panels/upgrade/gnome-upgrade-panel.desktop.in.in
+===================================================================
 --- /dev/null
-+++ b/panels/upgrade/gnome-upgrade-panel.desktop.in.in
++++ gnome-control-center/panels/upgrade/gnome-upgrade-panel.desktop.in.in
 @@ -0,0 +1,14 @@
 +[Desktop Entry]
 +Name=OS Upgrade & Recovery
@@ -249,8 +261,10 @@
 +Keywords=OS;Upgrade;
 +# Notifications are emitted by gnome-settings-daemon
 +X-GNOME-UsesNotifications=true
+Index: gnome-control-center/panels/upgrade/meson.build
+===================================================================
 --- /dev/null
-+++ b/panels/upgrade/meson.build
++++ gnome-control-center/panels/upgrade/meson.build
 @@ -0,0 +1,38 @@
 +panels_list += cappletname
 +desktop = 'gnome-@0@-panel.desktop'.format(cappletname)
@@ -290,9 +304,11 @@
 +  dependencies: deps,
 +  c_args: cflags
 +)
---- a/panels/meson.build
-+++ b/panels/meson.build
-@@ -29,6 +29,7 @@
+Index: gnome-control-center/panels/meson.build
+===================================================================
+--- gnome-control-center.orig/panels/meson.build
++++ gnome-control-center/panels/meson.build
+@@ -29,6 +29,7 @@ panels = [
    'ubuntu',
    'universal-access',
    'usage',
@@ -300,24 +316,28 @@
    'user-accounts',
    'wwan',
  ]
---- a/shell/cc-panel-list.c
-+++ b/shell/cc-panel-list.c
-@@ -422,6 +422,7 @@
+Index: gnome-control-center/shell/cc-panel-list.c
+===================================================================
+--- gnome-control-center.orig/shell/cc-panel-list.c
++++ gnome-control-center/shell/cc-panel-list.c
+@@ -421,6 +421,7 @@ static const gchar * const panel_order[]
+   "default-apps",
    "reset-settings",
    "datetime",
-   "info-overview",
 +  "upgrade",
+   "info-overview",
  };
  
- static guint
-@@ -1105,4 +1106,3 @@
+@@ -1105,4 +1106,3 @@ cc_panel_list_set_selection_mode (CcPane
        gtk_list_box_select_row (GTK_LIST_BOX (listbox), GTK_LIST_BOX_ROW (data->row));
      }
  }
 -
---- a/shell/cc-panel-loader.c
-+++ b/shell/cc-panel-loader.c
-@@ -63,6 +63,7 @@
+Index: gnome-control-center/shell/cc-panel-loader.c
+===================================================================
+--- gnome-control-center.orig/shell/cc-panel-loader.c
++++ gnome-control-center/shell/cc-panel-loader.c
+@@ -63,6 +63,7 @@ extern GType cc_bolt_panel_get_type (voi
  #endif /* BUILD_THUNDERBOLT */
  extern GType cc_ua_panel_get_type (void);
  extern GType cc_ubuntu_panel_get_type(void);
@@ -325,7 +345,7 @@
  extern GType cc_user_panel_get_type (void);
  #ifdef BUILD_WACOM
  extern GType cc_wacom_panel_get_type (void);
-@@ -138,6 +139,7 @@
+@@ -138,6 +139,7 @@ static CcPanelLoaderVtable default_panel
  #endif
    PANEL_TYPE("universal-access", cc_ua_panel_get_type,                   NULL),
    PANEL_TYPE("usage",            cc_usage_panel_get_type,                NULL),


### PR DESCRIPTION
This will require changes to pop-analytics-panel and pop-support-panel that I will make PRs for soon.
- [x] https://github.com/pop-os/support-panel/pull/7
- [x] https://github.com/pop-os/analytics-panel/pull/5
These can all be merged at once.