### PR TITLE
Don't set `X-GNOME-UsesNotifications` for Analytics Panel

### DIFF
--- a/debian/patches/pop/pop-analytics.patch
+++ b/debian/patches/pop/pop-analytics.patch
@@ -81,7 +81,7 @@
 +G_END_DECLS
 --- /dev/null
 +++ b/panels/analytics/gnome-analytics-panel.desktop.in.in
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,11 @@
 +[Desktop Entry]
 +Name=HP Analytics
 +Comment=Analytics info
@@ -93,8 +93,6 @@
 +StartupNotify=true
 +Categories=GNOME;GTK;Settings;X-GNOME-Settings-Panel;HardwareSettings;X-GNOME-PrivacySettings;
 +Keywords=hp;analytics;
-+# Notifications are emitted by gnome-settings-daemon
-+X-GNOME-UsesNotifications=true
 --- /dev/null
 +++ b/panels/analytics/meson.build
 @@ -0,0 +1,38 @@


### PR DESCRIPTION
Not needed, and caused it to show up in "Notifications" settings.