### PR TITLE
Fix word in "panels/cc-power-panel"

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4934,7 +4934,7 @@ msgstr "Escurecer a tela"
 
 #: panels/power/cc-power-panel.ui:161
 msgid "Reduces the screen brightness when the computer is inactive."
-msgstr "Reduz o brilho da tela quanod o computador está inativo."
+msgstr "Reduz o brilho da tela quando o computador está inativo."
 
 #: panels/power/cc-power-panel.ui:174
 msgid "Screen _Blank"


### PR DESCRIPTION
Correcting spelling error of the word "when" ("quando" in the Portuguese language).